### PR TITLE
Add pandas interface tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # fletcher
 
 [![CircleCI](https://circleci.com/gh/xhochy/fletcher/tree/master.svg?style=svg)](https://circleci.com/gh/xhochy/fletcher/tree/master)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 A library that provides a generic set of Pandas ExtensionDType/Array
 implementations backed by Apache Arrow. They support a wider range of types
@@ -15,17 +16,18 @@ using a `conda` based development setup with packages from `conda-forge`.
 ```
 # Create the conda environment with all necessary dependencies
 conda create -y -q -n fletcher python=3.6 \
+    black=18.5b0 \
+    codecov \
+    flake8 \
     numba \
     pandas \
+    pip \
+    pip \
     pyarrow \
     pytest \
     pytest-cov \
+    pytest-flake8 \
     six \
-    flake8 \
-    pip \
-    codecov \
-    pip \
-    black=18.5b0 \
     -c conda-forge
 
 # Activate the newly created environment

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ conda create -y -q -n fletcher python=3.6 \
     numba \
     pandas \
     pip \
-    pip \
     pyarrow \
     pytest \
     pytest-cov \

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -72,6 +72,13 @@ class FletcherArrayBase(ExtensionArray):
         For a boolean mask, return an instance of ``ExtensionArray``, filtered
         to the values where ``item`` is True.
         """
+        # Workaround for Arrow bug that segfaults on empty slice.
+        # This is fixed in Arrow master, will be released in 0.10
+        if isinstance(item, slice):
+            start = item.start or 0
+            stop = item.stop if item.stop is not None else len(self.data)
+            if stop - start == 0:
+                return type(self)(pa.column("dummy", pa.array([], type=self.data.type)))
         value = self.data[item]
         if isinstance(value, pa.ChunkedArray):
             return type(self)(value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 addopts = --flake8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+
+import operator
+
+import pytest
+
+
+@pytest.fixture
+def dtype():
+    """A fixture providing the ExtensionDtype to validate."""
+    raise NotImplementedError
+
+
+@pytest.fixture
+def data():
+    """Length-100 array for this type."""
+    raise NotImplementedError
+
+
+@pytest.fixture
+def data_missing():
+    """Length-2 array with [NA, Valid]"""
+    raise NotImplementedError
+
+
+@pytest.fixture(params=['data', 'data_missing'])
+def all_data(request, data, data_missing):
+    """Parametrized fixture giving 'data' and 'data_missing'"""
+    if request.param == 'data':
+        return data
+    elif request.param == 'data_missing':
+        return data_missing
+
+
+@pytest.fixture
+def data_for_sorting():
+    """Length-3 array with a known sort order.
+
+    This should be three items [B, C, A] with
+    A < B < C
+    """
+    raise NotImplementedError
+
+
+@pytest.fixture
+def data_missing_for_sorting():
+    """Length-3 array with a known sort order.
+
+    This should be three items [B, NA, A] with
+    A < B and NA missing.
+    """
+    raise NotImplementedError
+
+
+@pytest.fixture
+def na_cmp():
+    """Binary operator for comparing NA values.
+
+    Should return a function of two arguments that returns
+    True if both arguments are (scalar) NA for your type.
+
+    By default, uses ``operator.is_``
+    """
+    return operator.is_
+
+
+@pytest.fixture
+def na_value():
+    """The scalar missing value for this type. Default 'None'"""
+    return None
+
+
+@pytest.fixture
+def data_for_grouping():
+    """Data for factorization, grouping, and unique tests.
+
+    Expected to be like [B, B, NA, NA, A, A, B, C]
+
+    Where A < B < C and NA is missing
+    """
+    raise NotImplementedError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,22 +5,8 @@ import operator
 import pytest
 
 
-@pytest.fixture
-def dtype():
-    """A fixture providing the ExtensionDtype to validate."""
-    raise NotImplementedError
-
-
-@pytest.fixture
-def data():
-    """Length-100 array for this type."""
-    raise NotImplementedError
-
-
-@pytest.fixture
-def data_missing():
-    """Length-2 array with [NA, Valid]"""
-    raise NotImplementedError
+# More information about the pandas extension interface tests can be found here
+# https://github.com/pandas-dev/pandas/blob/master/pandas/tests/extension/base/__init__.py
 
 
 @pytest.fixture(params=["data", "data_missing"])
@@ -30,26 +16,6 @@ def all_data(request, data, data_missing):
         return data
     elif request.param == "data_missing":
         return data_missing
-
-
-@pytest.fixture
-def data_for_sorting():
-    """Length-3 array with a known sort order.
-
-    This should be three items [B, C, A] with
-    A < B < C
-    """
-    raise NotImplementedError
-
-
-@pytest.fixture
-def data_missing_for_sorting():
-    """Length-3 array with a known sort order.
-
-    This should be three items [B, NA, A] with
-    A < B and NA missing.
-    """
-    raise NotImplementedError
 
 
 @pytest.fixture
@@ -68,14 +34,3 @@ def na_cmp():
 def na_value():
     """The scalar missing value for this type. Default 'None'"""
     return None
-
-
-@pytest.fixture
-def data_for_grouping():
-    """Data for factorization, grouping, and unique tests.
-
-    Expected to be like [B, B, NA, NA, A, A, B, C]
-
-    Where A < B < C and NA is missing
-    """
-    raise NotImplementedError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 import operator
 
@@ -22,12 +23,12 @@ def data_missing():
     raise NotImplementedError
 
 
-@pytest.fixture(params=['data', 'data_missing'])
+@pytest.fixture(params=["data", "data_missing"])
 def all_data(request, data, data_missing):
     """Parametrized fixture giving 'data' and 'data_missing'"""
-    if request.param == 'data':
+    if request.param == "data":
         return data
-    elif request.param == 'data_missing':
+    elif request.param == "data_missing":
         return data_missing
 
 

--- a/tests/string_array/test_pandas_extension.py
+++ b/tests/string_array/test_pandas_extension.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 from pandas.tests.extension.base import (
     BaseCastingTests,

--- a/tests/string_array/test_pandas_extension.py
+++ b/tests/string_array/test_pandas_extension.py
@@ -17,8 +17,6 @@ from pandas.tests.extension.base import (
 from fletcher import StringDtype, StringArray
 from random import choice
 
-pytestmark = pytest.mark.xfail()
-
 
 @pytest.fixture
 def dtype():
@@ -67,41 +65,51 @@ def data_missing_for_sorting():
     raise StringArray(["B", None, "A"])
 
 
+@pytest.mark.xfail()
 class TestBaseCasting(BaseCastingTests):
     pass
 
 
+@pytest.mark.xfail()
 class TestBaseConstructors(BaseConstructorsTests):
     pass
 
 
+@pytest.mark.xfail()
 class TestBaseDtype(BaseDtypeTests):
     pass
 
 
+@pytest.mark.xfail()
 class TestBaseGetitemTests(BaseGetitemTests):
     pass
 
 
+@pytest.mark.xfail()
 class TestBaseGroupbyTests(BaseGroupbyTests):
     pass
 
 
+@pytest.mark.xfail()
 class TestBaseInterfaceTests(BaseInterfaceTests):
     pass
 
 
+@pytest.mark.xfail()
 class TestBaseMethodsTests(BaseMethodsTests):
     pass
 
 
+@pytest.mark.xfail()
 class TestBaseMissingTests(BaseMissingTests):
     pass
 
 
+@pytest.mark.xfail()
 class TestBaseReshapingTests(BaseReshapingTests):
     pass
 
 
+@pytest.mark.xfail()
 class TestBaseSetitemTests(BaseSetitemTests):
     pass

--- a/tests/string_array/test_pandas_extension.py
+++ b/tests/string_array/test_pandas_extension.py
@@ -1,0 +1,105 @@
+import pytest
+from pandas.tests.extension.base import (
+    BaseCastingTests,
+    BaseConstructorsTests,
+    BaseDtypeTests,
+    BaseGetitemTests,
+    BaseGroupbyTests,
+    BaseInterfaceTests,
+    BaseMethodsTests,
+    BaseMissingTests,
+    BaseReshapingTests,
+    BaseSetitemTests,
+)
+
+from fletcher import StringDtype, StringArray
+from random import choice
+
+pytestmark = pytest.mark.xfail()
+
+
+@pytest.fixture
+def dtype():
+    return StringDtype()
+
+
+@pytest.fixture
+def data():
+    candidates = ["a", "Ö", "Č", "🙈"]
+    return StringArray([choice(candidates) for x in range(100)])
+
+
+@pytest.fixture
+def data_missing():
+    return StringArray(["A", None])
+
+
+@pytest.fixture
+def data_for_grouping():
+    """Data for factorization, grouping, and unique tests.
+
+    Expected to be like [B, B, NA, NA, A, A, B, C]
+
+    Where A < B < C and NA is missing
+    """
+    raise StringArray(["B", "B", None, None, "A", "A", "B", "C"])
+
+
+@pytest.fixture
+def data_for_sorting():
+    """Length-3 array with a known sort order.
+
+    This should be three items [B, C, A] with
+    A < B < C
+    """
+    raise StringArray(["B", "C", "A"])
+
+
+@pytest.fixture
+def data_missing_for_sorting():
+    """Length-3 array with a known sort order.
+
+    This should be three items [B, NA, A] with
+    A < B and NA missing.
+    """
+    raise StringArray(["B", None, "A"])
+
+
+class TestBaseCasting(BaseCastingTests):
+    pass
+
+
+class TestBaseConstructors(BaseConstructorsTests):
+    pass
+
+
+class TestBaseDtype(BaseDtypeTests):
+    pass
+
+
+class TestBaseGetitemTests(BaseGetitemTests):
+    pass
+
+
+class TestBaseGroupbyTests(BaseGroupbyTests):
+    pass
+
+
+class TestBaseInterfaceTests(BaseInterfaceTests):
+    pass
+
+
+class TestBaseMethodsTests(BaseMethodsTests):
+    pass
+
+
+class TestBaseMissingTests(BaseMissingTests):
+    pass
+
+
+class TestBaseReshapingTests(BaseReshapingTests):
+    pass
+
+
+class TestBaseSetitemTests(BaseSetitemTests):
+    pass


### PR DESCRIPTION
* This adds all tests provided by pandas itself to validate their interface.
* On my machine it terminates at some point with a segfault :/
* I marked all tests as xfail until we can pin it down to a few tests
* We should consider putting each of the test cases into it's own module. for now, this would be fine for me though

Not sure if we can merge, yet. The segfault probably messes up the build entirely