### PR TITLE
Pandas interface __getitem__

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -11,6 +11,7 @@ from pandas.core.arrays import ExtensionArray
 import pyarrow as pa
 
 from ._algorithms import extract_isnull_bytemap
+from pandas.api.types import is_integer
 
 
 class FletcherArrayBase(ExtensionArray):
@@ -89,10 +90,11 @@ class FletcherArrayBase(ExtensionArray):
             indices = np.array(item)
             indices = np.argwhere(indices).flatten()
             return self.take(indices)
-        elif item >= len(self):
-            return None
-        elif item < 0:
-            item += len(self)
+        elif is_integer(item):
+            if item < 0:
+                item += len(self)
+            if item >= len(self):
+                return None
         value = self.data[item]
         if isinstance(value, pa.ChunkedArray):
             return type(self)(value)

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -97,11 +97,7 @@ class FletcherArrayBase(ExtensionArray):
         if isinstance(value, pa.ChunkedArray):
             return type(self)(value)
         else:
-            if isinstance(value, pa.lib.NAType):
-                return None
-            else:
-                # `as_py` is necessary due to https://issues.apache.org/jira/browse/ARROW-2694
-                return self.dtype.type(value.as_py())
+            return value.as_py()
 
     def isna(self):
         # type: () -> np.ndarray

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -80,6 +80,7 @@ class FletcherArrayBase(ExtensionArray):
         if isinstance(item, slice):
             start = item.start or 0
             stop = item.stop if item.stop is not None else len(self.data)
+            stop = min(stop, len(self.data))
             if stop - start == 0:
                 return type(self)(pa.array([], type=self.data.type))
 
@@ -88,8 +89,10 @@ class FletcherArrayBase(ExtensionArray):
             indices = np.array(item)
             indices = np.argwhere(indices).flatten()
             return self.take(indices)
-        elif item > len(self):
+        elif item >= len(self):
             return None
+        elif item < 0:
+            item += len(self)
         value = self.data[item]
         if isinstance(value, pa.ChunkedArray):
             return type(self)(value)

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -2,8 +2,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import abc
-
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -15,21 +13,9 @@ from ._numba_compat import NumbaString, NumbaStringArray
 from .base import FletcherArrayBase
 
 
-@six.add_metaclass(abc.ABCMeta)
-class StringDtypeType(object):
-    """
-    The type of StringDtype, this metaclass determines subclass ability
-    """
-    pass
-
-
-StringDtypeType.register(six.text_type)
-StringDtypeType.register(six.binary_type)
-
-
 class StringDtype(ExtensionDtype):
     name = "string"
-    type = StringDtypeType
+    type = six.text_type
     kind = "O"
 
     @classmethod

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -2,23 +2,29 @@
 
 from __future__ import absolute_import, division, print_function
 
+import abc
+
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import six
 from pandas.core.dtypes.dtypes import ExtensionDtype
-
-import pyarrow as pa
 
 from ._algorithms import _endswith, _startswith
 from ._numba_compat import NumbaString, NumbaStringArray
 from .base import FletcherArrayBase
 
 
-class StringDtypeType(six.text_type):
+@six.add_metaclass(abc.ABCMeta)
+class StringDtypeType(object):
     """
     The type of StringDtype, this metaclass determines subclass ability
     """
     pass
+
+
+StringDtypeType.register(six.text_type)
+StringDtypeType.register(six.binary_type)
 
 
 class StringDtype(ExtensionDtype):

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -2,18 +2,19 @@
 
 from __future__ import absolute_import, division, print_function
 
-from pandas.core.dtypes.dtypes import ExtensionDtype
-
 import numpy as np
 import pandas as pd
+import six
+from pandas.core.dtypes.dtypes import ExtensionDtype
+
 import pyarrow as pa
 
-from ._numba_compat import NumbaStringArray, NumbaString
-from ._algorithms import _startswith, _endswith
+from ._algorithms import _endswith, _startswith
+from ._numba_compat import NumbaString, NumbaStringArray
 from .base import FletcherArrayBase
 
 
-class StringDtypeType(object):
+class StringDtypeType(six.text_type):
     """
     The type of StringDtype, this metaclass determines subclass ability
     """
@@ -41,7 +42,7 @@ class StringArray(FletcherArrayBase):
             self.data = pa.chunked_array([pa.array(array, pa.string())])
         elif isinstance(array, pa.StringArray):
             self.data = pa.chunked_array([array])
-        elif isinstance(array, pa.ChunkedArray):
+        elif isinstance(array, (pa.ChunkedArray, pa.NullArray)):
             self.data = array
         else:
             raise ValueError(

--- a/tests/string_array/test_pandas_extension.py
+++ b/tests/string_array/test_pandas_extension.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+import six
 from pandas.tests.extension.base import (
     BaseCastingTests,
     BaseConstructorsTests,
@@ -14,7 +15,7 @@ from pandas.tests.extension.base import (
     BaseSetitemTests,
 )
 
-from fletcher import StringDtype, StringArray
+from fletcher import StringArray, StringDtype
 
 
 @pytest.fixture
@@ -65,7 +66,10 @@ def data_missing_for_sorting():
 
 
 class TestBaseCasting(BaseCastingTests):
-    pass
+
+    @pytest.mark.xfail(six.PY2, reason="Cast of UTF8 to `str` fails in py2.")
+    def test_astype_str(self, data):
+        BaseCastingTests.test_astype_str(self, data)
 
 
 class TestBaseConstructors(BaseConstructorsTests):

--- a/tests/string_array/test_pandas_extension.py
+++ b/tests/string_array/test_pandas_extension.py
@@ -15,7 +15,6 @@ from pandas.tests.extension.base import (
 )
 
 from fletcher import StringDtype, StringArray
-from random import choice
 
 
 @pytest.fixture
@@ -25,13 +24,13 @@ def dtype():
 
 @pytest.fixture
 def data():
-    candidates = ["a", "Ö", "Č", "🙈"]
-    return StringArray([choice(candidates) for x in range(100)])
+    candidates = [u"🙈", u"Ö", u"Č", u"a", u"B"]
+    return StringArray(candidates * 20)
 
 
 @pytest.fixture
 def data_missing():
-    return StringArray(["A", None])
+    return StringArray([None, "A"])
 
 
 @pytest.fixture
@@ -65,22 +64,18 @@ def data_missing_for_sorting():
     raise StringArray(["B", None, "A"])
 
 
-@pytest.mark.xfail()
 class TestBaseCasting(BaseCastingTests):
     pass
 
 
-@pytest.mark.xfail()
 class TestBaseConstructors(BaseConstructorsTests):
     pass
 
 
-@pytest.mark.xfail()
 class TestBaseDtype(BaseDtypeTests):
     pass
 
 
-@pytest.mark.xfail()
 class TestBaseGetitemTests(BaseGetitemTests):
     pass
 
@@ -90,7 +85,6 @@ class TestBaseGroupbyTests(BaseGroupbyTests):
     pass
 
 
-@pytest.mark.xfail()
 class TestBaseInterfaceTests(BaseInterfaceTests):
     pass
 


### PR DESCRIPTION
I'm assuming here that the current StringArray is only of type `unicode`. I believe we should provide two distinct types, e.g. `StringArray` and `BytesArray`. Implementation for both should be mostly the same, though.

5 interface test classes green
5 to go