### PR TITLE
Implement __setitem__

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -242,7 +242,7 @@ class FletcherArrayBase(ExtensionArray):
         -------
         ExtensionArray
         """
-        return cls(pa.array(scalars))
+        return cls(pa.array(scalars, cls.dtype.arrow_dtype))
 
     def take(self, indices, allow_fill=False, fill_value=None):
         # type: (Sequence[int], bool, Optional[Any]) -> ExtensionArray

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -53,6 +53,72 @@ class FletcherArrayBase(ExtensionArray):
             )
         )
 
+    def _get_chunk_offsets(self):
+        """
+        Returns an array holding the indices pointing to the first element of each chunk
+        """
+        offset = 0
+        offsets = []
+        for chunk in self.data.iterchunks():
+            offsets.append(offset)
+            offset += len(chunk)
+        return np.array(offsets)
+
+    def _get_chunk_indexer(self, array):
+        """
+        Returns an array with the chunk number for each index
+        """
+        res = np.empty(len(array), dtype=np.intp)
+        for ix, offset in enumerate(self._get_chunk_offsets()):
+            res = np.where(array >= offset, ix, res)
+        return res
+
+    def __setitem__(self, key, value):
+        # type: (Union[int, np.ndarray], Any) -> None
+        """Set one or more values inplace.
+
+        Parameters
+        ----------
+        key : int, ndarray, or slice
+            When called from, e.g. ``Series.__setitem__``, ``key`` will be
+            one of
+
+            * scalar int
+            * ndarray of integers.
+            * boolean ndarray
+            * slice object
+
+        value : ExtensionDtype.type, Sequence[ExtensionDtype.type], or object
+            value or values to be set of ``key``.
+
+        Returns
+        -------
+        None
+        """
+        # Convert all possible input key types to an array of integers
+        if is_bool_dtype(key) or isinstance(key, slice):
+            key = np.array(range(len(self)))[key]
+        elif is_integer(key):
+            key = np.array([key])
+        if np.isscalar(value):
+            value = np.full(len(key), value)
+
+        affected_chunks = self._get_chunk_indexer(key)
+        chunks = []
+        offset = 0
+        for ix, chunk in enumerate(self.data.iterchunks()):
+            if ix in affected_chunks:
+                key_chunk_indices = np.argwhere(affected_chunks == ix).flatten()
+                array_chunk_indices = key[key_chunk_indices] - offset
+                arr = chunk.to_pandas()
+                arr[array_chunk_indices] = np.array(value)[key_chunk_indices]
+                chunks.append(pa.array(arr, self.dtype.arrow_dtype))
+            else:
+                chunks.append(chunk)
+            offset += len(chunk)
+
+        self.data = pa.chunked_array(chunks)
+
     def __getitem__(self, item):
         # type (Any) -> Any
         """Select a subset of self.

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -18,6 +18,7 @@ class StringDtype(ExtensionDtype):
     name = "string"
     type = six.text_type
     kind = "O"
+    arrow_dtype = pa.string()
 
     @classmethod
     def construct_from_string(cls, string):
@@ -35,7 +36,7 @@ class StringArray(FletcherArrayBase):
             self.data = pa.chunked_array([pa.array(array, pa.string())])
         elif isinstance(array, pa.StringArray):
             self.data = pa.chunked_array([array])
-        elif isinstance(array, (pa.ChunkedArray, pa.NullArray)):
+        elif isinstance(array, pa.ChunkedArray):
             self.data = array
         else:
             raise ValueError(

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
         "Programming Language :: Python :: 3.6",
     ],
     packages=find_packages(),
-    install_requires=["pandas>=0.23.0", "pyarrow>=0.9.0", "six"],
+    install_requires=["pandas>=0.23.0", "pyarrow>=0.9.0", "numba", "six"],
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
+pytest-flake8
 flake8

--- a/tests/string_array/test_pandas_extension.py
+++ b/tests/string_array/test_pandas_extension.py
@@ -96,16 +96,13 @@ class TestBaseMethodsTests(BaseMethodsTests):
     pass
 
 
-@pytest.mark.xfail()
 class TestBaseMissingTests(BaseMissingTests):
     pass
 
 
-@pytest.mark.xfail()
 class TestBaseReshapingTests(BaseReshapingTests):
     pass
 
 
-@pytest.mark.xfail()
 class TestBaseSetitemTests(BaseSetitemTests):
     pass

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+import numpy.testing as npt
+import fletcher as fl
+import pyarrow as pa
+import pytest
+
+
+@pytest.fixture
+def array_inhom_chunks():
+    chunk1 = pa.array(list("abc"), pa.string())
+    chunk2 = pa.array(list("12345"), pa.string())
+    chunk3 = pa.array(list("Z"), pa.string())
+    chunked_array = pa.chunked_array([chunk1, chunk2, chunk3])
+    return fl.StringArray(chunked_array)
+
+
+def test_get_chunk_offsets(array_inhom_chunks):
+    actual = array_inhom_chunks._get_chunk_offsets()
+    expected = np.array([0, 3, 8])
+    npt.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "indices, expected",
+    [
+        (np.array(range(3)), np.full(3, 0)),
+        (np.array(range(3, 8)), np.full(5, 1)),
+        (np.array([8]), np.array([2])),
+        (np.array([0, 1, 5, 7, 8]), np.array([0, 0, 1, 1, 2])),
+        (np.array([5, 8, 0, 7, 1]), np.array([1, 2, 0, 1, 0])),
+    ],
+)
+def test_get_chunk_indexer(array_inhom_chunks, indices, expected):
+
+    actual = array_inhom_chunks._get_chunk_indexer(indices)
+    npt.assert_array_equal(actual, expected)

--- a/tests/test_pandas_integration.py
+++ b/tests/test_pandas_integration.py
@@ -19,6 +19,14 @@ TEST_LIST = ["Test", "string", None]
 TEST_ARRAY = pa.array(TEST_LIST)
 
 
+@pytest.fixture
+def test_array_chunked():
+    chunks = []
+    for _ in range(10):
+        chunks.append(pa.array(TEST_LIST))
+    return pa.chunked_array(chunks)
+
+
 # ----------------------------------------------------------------------------
 # Block Methods
 # ----------------------------------------------------------------------------
@@ -89,7 +97,6 @@ def test_getitem_slice():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(reason="Arrow arrays are not writable")
 def test_setitem_scalar():
     ser = pd.Series(fr.StringArray(TEST_ARRAY))
     ser[1] = "other_string"
@@ -180,3 +187,43 @@ def test_argsort(ascending, kind):
     result = s.argsort(ascending=ascending, kind=kind)
     expected = s.astype(object).argsort(ascending=ascending, kind=kind)
     tm.assert_frame_equal(result, expected)
+
+
+def test_fillna_chunked(test_array_chunked):
+    ser = pd.Series(fr.StringArray(test_array_chunked))
+    ser = ser.fillna("filled")
+
+    expected_list = TEST_LIST[:2] + ["filled"]
+    chunks = []
+    for _ in range(10):
+        chunks.append(pa.array(expected_list))
+    chunked_exp = pa.chunked_array(chunks)
+    expected = pd.Series(fr.StringArray(chunked_exp))
+
+    tm.assert_series_equal(ser, expected)
+
+
+def test_setitem_chunked(test_array_chunked):
+    ser = pd.Series(fr.StringArray(test_array_chunked))
+    new_val = "new_value"
+    old_val = ser[15]
+    assert new_val != old_val
+    ser[15] = new_val
+    assert new_val == ser[15]
+
+
+def test_setitem_chunked_bool_index(test_array_chunked):
+    ser = pd.Series(fr.StringArray(test_array_chunked))
+    bool_index = np.full(len(ser), False)
+    bool_index[15] = True
+    ser[bool_index] = "bool_value"
+    assert ser[15] == "bool_value"
+
+
+@pytest.mark.parametrize("indices", [[10, 15], [10, 11]])
+def test_setitem_chunked_int_index(indices, test_array_chunked):
+    ser = pd.Series(fr.StringArray(test_array_chunked))
+    integer_index = indices
+    ser[integer_index] = ["int", "index"]
+    assert ser[indices[0]] == "int"
+    assert ser[indices[1]] == "index"


### PR DESCRIPTION
This implements the __setitem__ method (not fast or efficient, but hopefully working). This also fixes the remaining pandas interface issues

FYI: I ran into a very nasty segfault because I tried to use `pa.ChunkedArray` instead of `pa.chunked_array`. You opened a similar issue for the plain array class, didn't you? @xhochy 

Closes #23 #32 #33
