### PR TITLE
Use fast path for item.step = None

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -6,7 +6,7 @@ class TimeSuite:
 
     def setup(self):
         array = [
-            str(x) + str(x) + str(x) if x % 7 == 0 else None for x in range(2 ** 15)
+            str(x) + str(x) + str(x) if x % 7 == 0 else None for x in range(2 ** 20)
         ]
         self.df = pd.DataFrame({"str": array})
         self.df_ext = pd.DataFrame({"str": fr.FletcherArray(array)})
@@ -34,3 +34,9 @@ class TimeSuite:
 
     def time_endswith_na_ext(self):
         self.df_ext["str"].text.endswith("10", na=False)
+
+    def time_concat(self):
+        pd.concat([self.df["str"]] * 2)
+
+    def time_concat_ext(self):
+        pd.concat([self.df_ext["str"]] * 2)

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -225,9 +225,10 @@ class FletcherArray(ExtensionArray):
             start = item.start or 0
             stop = item.stop if item.stop is not None else len(self.data)
             stop = min(stop, len(self.data))
+            step = item.step if item.step is not None else 1
             # Arrow can't handle slices with steps other than 1
             # https://issues.apache.org/jira/browse/ARROW-2714
-            if item.step != 1:
+            if step != 1:
                 return type(self)(np.asarray(self)[item], dtype=self.data.type)
             if stop - start == 0:
                 return type(self)(pa.array([], type=self.data.type))


### PR DESCRIPTION
Fixes a recently introduced performance regression.