### PR TITLE
Test against Pandas nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,19 @@ jobs:
           path: test-reports
       - store_artifacts:
           path: test-reports
+  "python-3.6-dev-versions":
+    working_directory: ~/fletcher-circleci
+    docker:
+      # We use our own Python, so the version here is not relevant
+      - image: circleci/python:3.6.1
+    steps:
+      - checkout
+      - run: # install and activate virtual environment with pip
+          command: ./ci/circle_build_linux.sh 3.6 1
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           path: test-reports
       - store_artifacts:
           path: test-reports
-  "python-3.6-dev-versions":
+  "upstream-dev":
     working_directory: ~/fletcher-circleci
     docker:
       # We use our own Python, so the version here is not relevant
@@ -46,3 +46,4 @@ workflows:
     jobs:
       - "python-2.7"
       - "python-3.6"
+      - "upstream-dev"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 18.5b0
+    hooks:
+      - id: black
+        args: [--safe]
+        python_version: python3.6
+
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: v1.2.3
+    hooks:
+    -   id: flake8

--- a/ci/circle_build_linux.sh
+++ b/ci/circle_build_linux.sh
@@ -3,6 +3,7 @@
 set -eo pipefail
 
 export PYTHON_VERSION=$1
+export USE_DEV_WHEELS=$2
 export CONDA_PKGS_DIRS=$HOME/.conda_packages
 export MINICONDA=$HOME/miniconda
 export MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
@@ -26,6 +27,13 @@ conda create -y -q -n fletcher python=${PYTHON_VERSION} \
     codecov \
     six \
     -c conda-forge
+
+if [[ ${USE_DEV_WHEELS} ]]; then
+    echo "Installing NumPy and Pandas dev"
+    conda uninstall -y --force numpy pandas
+    PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
+    pip install --pre --no-deps --upgrade --timeout=60 -f $PRE_WHEELS numpy pandas
+fi
 
 source activate fletcher
 pip install -e .

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -47,10 +47,10 @@ class FletcherDtype(ExtensionDtype):
         self.arrow_dtype = arrow_dtype
 
     def __str__(self):
-        return str(self.arrow_dtype)
+        return "fletcher[{}]".format(self.arrow_dtype)
 
     def __repr__(self):
-        return "FletcherDType({})".format(str(self))
+        return "FletcherDType({})".format(str(self.arrow_dtype))
 
     def __eq__(self, other):
         """Check whether 'other' is equal to self.
@@ -103,7 +103,7 @@ class FletcherDtype(ExtensionDtype):
         """A string identifying the data type.
         Will be used for display in, e.g. ``Series.dtype``
         """
-        return str(self.arrow_dtype)
+        return str(self)
 
     @classmethod
     def construct_from_string(cls, string):
@@ -130,6 +130,10 @@ class FletcherDtype(ExtensionDtype):
         ...         raise TypeError("Cannot construct a '{}' from "
         ...                         "'{}'".format(cls, string))
         """
+        # Remove fletcher specific naming from the arrow type string.
+        if string.startswith("fletcher["):
+            string = string[9:-1]
+
         return cls(pa.type_for_alias(string))
 
 

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -140,7 +140,7 @@ class FletcherDtype(ExtensionDtype):
         return cls(pa.type_for_alias(string))
 
     @classmethod
-    def construct_array_type(cls):
+    def construct_array_type(cls, *args):
         """
         Return the array type associated with this dtype
 
@@ -148,6 +148,8 @@ class FletcherDtype(ExtensionDtype):
         -------
         type
         """
+        if len(args) > 0:
+            raise NotImplementedError("construct_array_type does not support arguments")
         return FletcherArray
 
 

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -290,6 +290,7 @@ class FletcherArray(ExtensionArray):
                     if not arr.flags.writeable:
                         arr = arr.copy()
                     arr[array_chunk_indices] = np.array(value)[key_chunk_indices]
+                    # ARROW-2806: Inconsistent handling of np.nan requires adding a mask
                     if pa.types.is_integer(
                         self.dtype.arrow_dtype
                     ) or pa.types.is_floating(self.dtype.arrow_dtype):
@@ -336,6 +337,7 @@ class FletcherArray(ExtensionArray):
             # https://issues.apache.org/jira/browse/ARROW-2714
             if step != 1:
                 arr = np.asarray(self)[item]
+                # ARROW-2806: Inconsistent handling of np.nan requires adding a mask
                 if pa.types.is_integer(self.dtype.arrow_dtype) or pa.types.is_floating(
                     self.dtype.arrow_dtype
                 ):

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -139,11 +139,24 @@ class FletcherDtype(ExtensionDtype):
 
         return cls(pa.type_for_alias(string))
 
+    @classmethod
+    def construct_array_type(cls):
+        """
+        Return the array type associated with this dtype
+
+        Returns
+        -------
+        type
+        """
+        return FletcherArray
+
 
 class FletcherArray(ExtensionArray):
     _can_hold_na = True
 
-    def __init__(self, array, dtype=None):
+    def __init__(self, array, dtype=None, copy=None):
+        # Copy is not used at the moment. It's only affect will be when we
+        # allow array to be a FletcherArray
         if is_array_like(array) or isinstance(array, list):
             self.data = pa.chunked_array([pa.array(array, type=dtype)])
         elif isinstance(array, pa.Array):

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -485,6 +485,8 @@ class FletcherArray(ExtensionArray):
             raise NotImplementedError("Cast propagation in astype not yet implemented")
         else:
             dtype = np.dtype(dtype)
+            # NumPy's conversion of list->unicode is differently from Python's
+            # default. We want to have the default Python output, so force it here.
             if pa.types.is_list(self.dtype.arrow_dtype) and dtype.kind == "U":
                 return np.vectorize(six.text_type)(np.asarray(self))
             return np.asarray(self).astype(dtype)

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -202,7 +202,14 @@ class TestBaseCasting(BaseCastingTests):
 
 
 class TestBaseConstructors(BaseConstructorsTests):
-    pass
+
+    @pytest.mark.xfail(reason="Tries to construct dtypes with np.dtype")
+    def test_from_dtype(self, data):
+        if pa.types.is_string(data.dtype.arrow_dtype):
+            pytest.xfail(
+                "String construction is failing as Pandas wants to pass the FletcherDtype to NumPy"
+            )
+        BaseConstructorsTests.test_from_dtype(self, data)
 
 
 class TestBaseDtype(BaseDtypeTests):
@@ -272,6 +279,9 @@ class TestBaseMethodsTests(BaseMethodsTests):
 
     @pytest.mark.parametrize("dropna", [True, False])
     def test_value_counts(self, all_data, dropna, dtype):
+        if LooseVersion(pd.__version__) >= "0.24.0dev0":
+            pytest.skip("Master requires value_counts but not part of the interface")
+            return
         # Skip integer tests while there is no support for ExtensionIndex.
         # The dropna=True variant will produce a mix of IntIndex and FloatIndex.
         if dtype.name == "fletcher[int64]":

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -236,36 +236,6 @@ class TestBaseGetitemTests(BaseGetitemTests):
         # due to a dtype assumption that does not hold for Arrow
         pass
 
-    def test_get(self, data, dtype):
-        if pa.types.is_list(dtype.arrow_dtype):
-            pytest.skip("assert_extension_array_equal casts to numpy object arrays")
-        else:
-            BaseGetitemTests.test_get(self, data)
-
-    def test_loc_series(self, data, dtype):
-        if pa.types.is_list(dtype.arrow_dtype):
-            pytest.skip("assert_extension_array_equal casts to numpy object arrays")
-        else:
-            BaseGetitemTests.test_loc_series(self, data)
-
-    def test_loc_frame(self, data, dtype):
-        if pa.types.is_list(dtype.arrow_dtype):
-            pytest.skip("assert_extension_array_equal casts to numpy object arrays")
-        else:
-            BaseGetitemTests.test_loc_frame(self, data)
-
-    def test_iloc_series(self, data, dtype):
-        if pa.types.is_list(dtype.arrow_dtype):
-            pytest.skip("assert_extension_array_equal casts to numpy object arrays")
-        else:
-            BaseGetitemTests.test_iloc_series(self, data)
-
-    def test_iloc_frame(self, data, dtype):
-        if pa.types.is_list(dtype.arrow_dtype):
-            pytest.skip("assert_extension_array_equal casts to numpy object arrays")
-        else:
-            BaseGetitemTests.test_iloc_frame(self, data)
-
 
 class TestBaseGroupbyTests(BaseGroupbyTests):
     pass

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -304,7 +304,7 @@ class TestBaseReshapingTests(BaseReshapingTests):
 
     def test_concat_mixed_dtypes(self, data, dtype):
         if dtype.name in ["fletcher[int64]", "fletcher[double]"]:
-            # TODO: Raise issue if this is expected.
+            # https://github.com/pandas-dev/pandas/issues/21792
             pytest.skip("pd.concat(int64, fletcher[int64] yields int64")
         else:
             BaseReshapingTests.test_concat_mixed_dtypes(self, data)

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -8,6 +8,7 @@ import six
 import string
 import sys
 from collections import namedtuple
+from distutils.version import LooseVersion
 from pandas.tests.extension.base import (
     BaseCastingTests,
     BaseConstructorsTests,
@@ -279,6 +280,9 @@ class TestBaseMethodsTests(BaseMethodsTests):
             BaseMethodsTests.test_value_counts(self, all_data, dropna)
 
     def test_combine_le(self, data_repeated):
+        if LooseVersion(pd.__version__) <= "0.24.0dev0":
+            pytest.skip("Test only exists on master")
+            return
         # GH 20825
         # Test that combine works when doing a <= (le) comparison
         # Fletcher returns 'fletcher[bool]' instead of np.bool as dtype
@@ -301,6 +305,9 @@ class TestBaseMethodsTests(BaseMethodsTests):
         self.assert_series_equal(result, expected)
 
     def test_combine_add(self, data_repeated, dtype):
+        if LooseVersion(pd.__version__) <= "0.24.0dev0":
+            pytest.skip("Test only exists on master")
+            return
         if dtype.name == "fletcher[date64[ms]]":
             pytest.skip(
                 "unsupported operand type(s) for +: 'datetime.date' and 'datetime.date"

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -251,7 +251,6 @@ class TestBaseMethodsTests(BaseMethodsTests):
     def test_value_counts(self, all_data, dropna, dtype):
         if LooseVersion(pd.__version__) >= "0.24.0dev0":
             pytest.skip("Master requires value_counts but not part of the interface")
-            return
         # Skip integer tests while there is no support for ExtensionIndex.
         # The dropna=True variant will produce a mix of IntIndex and FloatIndex.
         if dtype.name == "fletcher[int64]":
@@ -262,7 +261,6 @@ class TestBaseMethodsTests(BaseMethodsTests):
     def test_combine_le(self, data_repeated):
         if LooseVersion(pd.__version__) <= "0.24.0dev0":
             pytest.skip("Test only exists on master")
-            return
         # GH 20825
         # Test that combine works when doing a <= (le) comparison
         # Fletcher returns 'fletcher[bool]' instead of np.bool as dtype
@@ -287,7 +285,6 @@ class TestBaseMethodsTests(BaseMethodsTests):
     def test_combine_add(self, data_repeated, dtype):
         if LooseVersion(pd.__version__) <= "0.24.0dev0":
             pytest.skip("Test only exists on master")
-            return
         if dtype.name == "fletcher[date64[ms]]":
             pytest.skip(
                 "unsupported operand type(s) for +: 'datetime.date' and 'datetime.date"


### PR DESCRIPTION
Adds tests for list, int64 and float64 types. Sadly they all fail on all pandas releases. I have marked the failures and will fix them upstream.

Fixes #43 
Fixes #44 
Fixes #46 
Fixes #11