### PR TITLE
Enable int64 and float64 tests for Pandas nightly

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -520,7 +520,7 @@ class FletcherArray(ExtensionArray):
         """
         if dtype and isinstance(dtype, FletcherDtype):
             dtype = dtype.arrow_dtype
-        return cls(pa.array(scalars, type=dtype))
+        return cls(pa.array(scalars, type=dtype, from_pandas=True))
 
     def fillna(self, value=None, method=None, limit=None):
         """ Fill NA/NaN values using the specified method.


### PR DESCRIPTION
The respective PR was merged. Maybe too late to make it into today's nightly but CI will tell.