### PR TITLE
Use IPython extension for sphinx docs

### DIFF
--- a/ci/circle_build_linux.sh
+++ b/ci/circle_build_linux.sh
@@ -20,12 +20,18 @@ conda config --add channels https://repo.continuum.io/pkgs/free
 conda config --add channels conda-forge
 
 conda create -y -q -n fletcher python=${PYTHON_VERSION} \
-    pandas pyarrow pytest pytest-cov pytest-flake8 \
-    flake8 \
-    setuptools_scm \
-    pip \
-    numba \
     codecov \
+    flake8 \
+    ipython \
+    matplotlib \
+    numba \
+    pandas \
+    pip \
+    pyarrow \
+    pytest \
+    pytest-cov \
+    pytest-flake8 \
+    setuptools_scm \
     six \
     sphinx \
     -c conda-forge

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,12 +39,14 @@ release = ""
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "IPython.sphinxext.ipython_console_highlighting",
+    "IPython.sphinxext.ipython_directive",
     "sphinx.ext.autodoc",
-    "sphinx.ext.doctest",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
-    "sphinx.ext.viewcode",
+    "sphinx.ext.doctest",
     "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -91,7 +93,7 @@ html_theme = "alabaster"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,22 +19,19 @@ or otherwise provide an implementation by itself using Numba.
 
 Usage of fletcher columns is straightforward using Pandas' default constructor:
 
-.. code::
+.. ipython::
 
-    import fletcher as fr
-    import pandas as pd
+    In [2]: import fletcher as fr
 
-    df = pd.DataFrame({
-        'str_column': fr.FletcherArray(['Test', None, 'Strings'])
-    })
-    df.info()
+    In [3]: import pandas as pd
 
-    # <class 'pandas.core.frame.DataFrame'>
-    # RangeIndex: 3 entries, 0 to 2
-    # Data columns (total 1 columns):
-    # str_column    2 non-null string
-    # dtypes: string(1)
-    # memory usage: 108.0 bytes
+    In [4]: df = pd.DataFrame({
+       ...:          'str_column': fr.FletcherArray(
+       ...:              ['Test', None, 'Strings']
+       ...:          )
+       ...:      })
+
+    In [5]: df.info()
 
 
 * :ref:`genindex`


### PR DESCRIPTION
Pro: We can use the extension and the docs are always up-to-date

Con: We need to install `ipdb` and `matplotlib` during build

Thoughts?