### PR TITLE
Get and setitem performance

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,15 +1,21 @@
 import pandas as pd
 import fletcher as fr
+import pyarrow as pa
+import numpy as np
+
+
+def generate_test_array(n):
+    return [str(x) + str(x) + str(x) if x % 7 == 0 else None for x in range(n)]
 
 
 class TimeSuite:
 
     def setup(self):
-        array = [
-            str(x) + str(x) + str(x) if x % 7 == 0 else None for x in range(2 ** 20)
-        ]
+        array = generate_test_array(2 ** 15)
         self.df = pd.DataFrame({"str": array})
-        self.df_ext = pd.DataFrame({"str": fr.FletcherArray(array)})
+        self.df_ext = pd.DataFrame(
+            {"str": fr.FletcherArray(pa.array(array, pa.string()))}
+        )
 
     def time_isnull(self):
         self.df["str"].isnull()
@@ -40,3 +46,62 @@ class TimeSuite:
 
     def time_concat_ext(self):
         pd.concat([self.df_ext["str"]] * 2)
+
+
+class Indexing(object):
+    n = 2 ** 12
+
+    params = [
+        (True, False),
+        ("scalar_value", "array_value"),
+        ("int", "int_array", "bool_array", "slice"),
+    ]
+    param_names = ["chunked", "values", "indices"]
+
+    def setup(self, chunked, value, indices):
+        # assert np.isscalar(values) or len(values) == len(indices)
+        array = generate_test_array(self.n)
+        if indices == "int":
+            if value == "array_value":
+                raise NotImplementedError()
+            self.indexer = 50
+        elif indices == "int_array":
+            self.indexer = list(range(0, self.n, 5))
+        elif indices == "bool_array":
+            self.indexer = np.zeros(self.n, dtype=bool)
+            self.indexer[list(range(0, self.n, 5))] = True
+        elif indices == "slice":
+            self.indexer = slice(0, self.n, 5)
+
+        if value == "scalar_value":
+            self.value = "setitem"
+        elif value == "array_value":
+            self.value = [str(x) for x in range(self.n)]
+            self.value = np.array(self.value)[self.indexer]
+            if len(self.value) == 1:
+                self.value = self.value[0]
+
+        self.df = pd.DataFrame({"str": array})
+        if chunked:
+            array = np.array_split(array, 1000)
+        else:
+            array = [array]
+        self.df_ext = pd.DataFrame(
+            {
+                "str": fr.FletcherArray(
+                    pa.chunked_array([pa.array(chunk, pa.string()) for chunk in array])
+                )
+            }
+        )
+
+    def time_getitem(self, chunked, value, indices):
+        self.df_ext["str"][self.indexer]
+
+    def time_getitem_obj(self, chunked, value, indices):
+        self.df["str"][self.indexer]
+
+    def time_setitem(self, chunked, value, indices):
+        self.df_ext["str"][self.indexer] = self.value
+
+    def time_setitem_obj(self, chunked, value, indices):
+        self.df["str"][self.indexer] = self.value

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,11 +1,16 @@
-import pandas as pd
-import fletcher as fr
-import pyarrow as pa
 import numpy as np
+import pandas as pd
+import pyarrow as pa
+import six
+
+import fletcher as fr
 
 
 def generate_test_array(n):
-    return [str(x) + str(x) + str(x) if x % 7 == 0 else None for x in range(n)]
+    return [
+        six.text_type(x) + six.text_type(x) + six.text_type(x) if x % 7 == 0 else None
+        for x in range(n)
+    ]
 
 
 class TimeSuite:

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -172,12 +172,7 @@ class FletcherArray(ExtensionArray):
                 "Unsupported type passed for {}: {}".format(self.__name__, type(array))
             )
         self._dtype = FletcherDtype(self.data.type)
-        offset = 0
-        offsets = np.empty(self.data.num_chunks, dtype=np.intp)
-        for ix, chunk in enumerate(self.data.iterchunks()):
-            offsets[ix] = offset
-            offset += len(chunk)
-        self.offsets = offsets
+        self.offsets = self._calculate_chunk_offsets()
 
     @property
     def dtype(self):
@@ -224,6 +219,17 @@ class FletcherArray(ExtensionArray):
                 [array for ea in to_concat for array in ea.data.iterchunks()]
             )
         )
+
+    def _calculate_chunk_offsets(self):
+        """
+        Returns an array holding the indices pointing to the first element of each chunk
+        """
+        offset = 0
+        offsets = []
+        for chunk in self.data.iterchunks():
+            offsets.append(offset)
+            offset += len(chunk)
+        return np.array(offsets)
 
     def _get_chunk_indexer(self, array):
         """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -18,12 +18,6 @@ def array_inhom_chunks():
     return fl.FletcherArray(chunked_array)
 
 
-def test_get_chunk_offsets(array_inhom_chunks):
-    actual = array_inhom_chunks._get_chunk_offsets()
-    expected = np.array([0, 3, 8])
-    npt.assert_array_equal(actual, expected)
-
-
 @pytest.mark.parametrize(
     "indices, expected",
     [


### PR DESCRIPTION
This adds benchmarks for get/seitem and improves performance of setitem by upto a factor of 5. We're still *far* away from where we should be but with these changes we're basically limited in how fast `arrow->pandas->arrow` conversion is done

The _complexity_ of the benchmark setup is there to receive better output since the parameters are strings instead of arrays