### PR TITLE
Fixing typo when raising a ValueError in FletcherArray constructor

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -169,7 +169,8 @@ class FletcherArray(ExtensionArray):
             self.data = array
         else:
             raise ValueError(
-                "Unsupported type passed for {}: {}".format(self.__name__, type(array))
+                "Unsupported type passed for {}: {}".format(self.__class__.__name__,
+                                                            type(array))
             )
         self._dtype = FletcherDtype(self.data.type)
         self.offsets = self._calculate_chunk_offsets()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -32,3 +32,8 @@ def test_get_chunk_indexer(array_inhom_chunks, indices, expected):
 
     actual = array_inhom_chunks._get_chunk_indexer(indices)
     npt.assert_array_equal(actual, expected)
+
+
+def test_fletcherarray_constructor():
+    with pytest.raises(ValueError):
+        fl.FletcherArray(None)


### PR DESCRIPTION
Fixing typo in exception message:

```
Python 3.6.6 | packaged by conda-forge | (default, Jul 26 2018, 11:48:23) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import fletcher
>>> fletcher.FletcherArray(None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\DDrive\msys2\home\UKC2892\src\fletcher\fletcher\base.py", line 172, in __init__
    "Unsupported type passed for {}: {}".format(self.__name__, type(array))
AttributeError: 'FletcherArray' object has no attribute '__name__'
```