### PR TITLE
Adding conda environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+name: fletcher
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pandas>=0.23
+  - pyarrow>=0.9
+  - numba
+  - six
+  - pytest
+  - pytest-cov
+  - flake8
+  - pytest-flake8


### PR DESCRIPTION
I think it'd be useful to have a conda environment file, so an environment with all the dependencies can be simply created with `conda env create` from the repo directory.