### PR TITLE
WIP Prepare for arrow and pandas releases

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -4,7 +4,13 @@ from __future__ import absolute_import, division, print_function
 
 from ._algorithms import extract_isnull_bytemap
 from collections import Iterable, OrderedDict
-from pandas.api.types import is_array_like, is_bool_dtype, is_integer, is_integer_dtype
+from pandas.api.types import (
+    is_array_like,
+    is_bool_dtype,
+    is_integer,
+    is_integer_dtype,
+    is_int64_dtype,
+)
 from pandas.core.arrays import ExtensionArray
 from pandas.core.dtypes.dtypes import ExtensionDtype
 
@@ -184,15 +190,15 @@ class FletcherArray(ExtensionArray):
         # type: () -> ExtensionDtype
         return self._dtype
 
-    def __array__(self):
+    def __array__(self, copy=None):
         """
         Correctly construct numpy arrays when passed to `np.asarray()`.
         """
-        # TODO: Otherwise segfaults on reconstruction of date arrays.
-        #   Fixed in Arrow master post 0.9
-        if pa.types.is_date(self.data.type):
-            return np.array(pa.column("dummy", self.data).to_pylist())
-        return pa.column("dummy", self.data).to_pandas().values
+        if copy:
+            data = self.data.copy()
+        else:
+            data = self.data
+        return pa.column("dummy", data).to_pandas().values
 
     def __len__(self):
         """
@@ -281,6 +287,9 @@ class FletcherArray(ExtensionArray):
         else:
             value = np.asarray(value)
 
+        if len(key) != len(value):
+            raise ValueError("Length mismatch between index and value.")
+
         affected_chunks_index = self._get_chunk_indexer(key)
         affected_chunks_unique = np.unique(affected_chunks_index)
 
@@ -306,16 +315,18 @@ class FletcherArray(ExtensionArray):
                 # the resulting arrays are read-only.
                 if not arr.flags.writeable:
                     arr = arr.copy()
-
                 arr[array_chunk_indices] = value[key_chunk_indices]
 
+                mask = None
                 # ARROW-2806: Inconsistent handling of np.nan requires adding a mask
                 if pa.types.is_integer(self.dtype.arrow_dtype) or pa.types.is_floating(
                     self.dtype.arrow_dtype
                 ):
-                    mask = pd.isna(arr)
-                else:
-                    mask = None
+                    nan_values = pd.isna(value[key_chunk_indices])
+                    if any(nan_values):
+                        nan_index = key_chunk_indices & nan_values
+                        mask = np.ones_like(arr, dtype=bool)
+                        mask[nan_index] = False
                 pa_arr = pa.array(arr, self.dtype.arrow_dtype, mask=mask)
             all_chunks[ix] = pa_arr
 
@@ -475,6 +486,8 @@ class FletcherArray(ExtensionArray):
             if indices.dtype.kind == "f":
                 indices[np.isnan(indices)] = na_sentinel
                 indices = indices.astype(int)
+            if not is_int64_dtype(indices):
+                indices = indices.astype(np.int64)
             return indices, type(self)(encoded.dictionary)
         else:
             np_array = pa.column("dummy", self.data).to_pandas().values
@@ -498,18 +511,29 @@ class FletcherArray(ExtensionArray):
         array : ndarray
             NumPy ndarray with 'dtype' for its dtype.
         """
-        if isinstance(dtype, pa.DataType):
-            raise NotImplementedError("Cast propagation in astype not yet implemented")
+        if self.dtype == dtype:
+            return self
+
+        if isinstance(dtype, FletcherDtype):
+            dtype = dtype.arrow_dtype.to_pandas_dtype()
+            arrow_type = dtype.arrow_dtype
+        elif isinstance(dtype, pa.DataType):
+            dtype = dtype.to_pandas_dtype()
+            arrow_type = dtype
         else:
             dtype = np.dtype(dtype)
-            # NumPy's conversion of list->unicode is differently from Python's
-            # default. We want to have the default Python output, so force it here.
-            if pa.types.is_list(self.dtype.arrow_dtype) and dtype.kind == "U":
-                return np.vectorize(six.text_type)(np.asarray(self))
+            arrow_type = None
+        # NumPy's conversion of list->unicode is differently from Python's
+        # default. We want to have the default Python output, so force it here.
+        if pa.types.is_list(self.dtype.arrow_dtype) and dtype.kind == "U":
+            return np.vectorize(six.text_type)(np.asarray(self))
+        if arrow_type is not None:
+            return FletcherArray(np.asarray(self).astype(dtype), dtype=arrow_type)
+        else:
             return np.asarray(self).astype(dtype)
 
     @classmethod
-    def _from_sequence(cls, scalars, dtype=None):
+    def _from_sequence(cls, scalars, dtype=None, copy=None):
         """
         Construct a new ExtensionArray from a sequence of scalars.
 
@@ -523,6 +547,8 @@ class FletcherArray(ExtensionArray):
         -------
         ExtensionArray
         """
+        if isinstance(scalars, FletcherArray):
+            return scalars
         if dtype and isinstance(dtype, FletcherDtype):
             dtype = dtype.arrow_dtype
         return cls(pa.array(scalars, type=dtype, from_pandas=True))

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -252,7 +252,6 @@ class TestBaseGetitemTests(BaseGetitemTests):
         else:
             BaseGetitemTests.test_reindex_non_na_fill_value(self, data_missing)
 
-    @fail_on_missing_dtype_in_from_sequence
     def test_take_series(self, data):
         BaseGetitemTests.test_take_series(self, data)
 
@@ -336,7 +335,6 @@ class TestBaseMethodsTests(BaseMethodsTests):
         else:
             BaseMethodsTests.test_combine_add(self, data_repeated)
 
-    @fail_on_missing_dtype_in_from_sequence
     @pytest.mark.parametrize("na_sentinel", [-1, -2])
     def test_factorize(self, data_for_grouping, na_sentinel):
         if LooseVersion(pd.__version__) <= "0.24.0dev0":
@@ -344,7 +342,6 @@ class TestBaseMethodsTests(BaseMethodsTests):
         BaseMethodsTests.test_factorize(self, data_for_grouping, na_sentinel)
 
     @pytest.mark.parametrize("na_sentinel", [-1, -2])
-    @fail_on_missing_dtype_in_from_sequence
     def test_factorize_equivalence(self, data_for_grouping, na_sentinel):
         if LooseVersion(pd.__version__) <= "0.24.0dev0":
             pytest.skip("Test only exists on master")
@@ -364,7 +361,6 @@ class TestBaseMissingTests(BaseMissingTests):
     def test_fillna_series_method(self, data_missing, method):
         BaseMissingTests.test_fillna_series_method(self, data_missing, method)
 
-    @fail_on_missing_dtype_in_from_sequence
     def test_fillna_frame(self, data_missing):
         BaseMissingTests.test_fillna_frame(self, data_missing)
 
@@ -378,23 +374,18 @@ class TestBaseReshapingTests(BaseReshapingTests):
         else:
             BaseReshapingTests.test_concat_mixed_dtypes(self, data)
 
-    @fail_on_missing_dtype_in_from_sequence
     def test_concat_columns(self, data, na_value):
         BaseReshapingTests.test_concat_columns(self, data, na_value)
 
-    @fail_on_missing_dtype_in_from_sequence
     def test_align(self, data, na_value):
         BaseReshapingTests.test_align(self, data, na_value)
 
-    @fail_on_missing_dtype_in_from_sequence
     def test_align_frame(self, data, na_value):
         BaseReshapingTests.test_align_frame(self, data, na_value)
 
-    @fail_on_missing_dtype_in_from_sequence
     def test_align_series_frame(self, data, na_value):
         BaseReshapingTests.test_align_series_frame(self, data, na_value)
 
-    @fail_on_missing_dtype_in_from_sequence
     def test_merge(self, data, na_value):
         BaseReshapingTests.test_merge(self, data, na_value)
 


### PR DESCRIPTION
This fixes some issues which come up when running against current arrow and pandas masters. Mostly they come up because the pandas tests cover more edge cases.
What's still left to do is implement the new `copy` kwargs properly (and possibly wait for the actual releases)