### PR TITLE
Pytest 3.7 and higher

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -19,6 +19,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import six
+from typing import Any, Optional, Sequence, Tuple, Union
 
 
 _python_type_map = {
@@ -449,7 +450,7 @@ class FletcherArray(ExtensionArray):
         return self.data
 
     def factorize(self, na_sentinel=-1):
-        # type: (int) -> Tuple[ndarray, ExtensionArray]
+        # type: (int) -> Tuple[np.ndarray, ExtensionArray]
         """Encode the extension array as an enumerated type.
         Parameters
         ----------

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from fletcher import FletcherArray, FletcherDtype
 
 import datetime
 import pandas as pd
@@ -22,7 +23,16 @@ from pandas.tests.extension.base import (
     BaseSetitemTests,
 )
 
-from fletcher import FletcherArray, FletcherDtype
+if LooseVersion(pd.__version__) >= "0.25.0":
+    # imports of pytest fixtures needed for derived unittest classes
+    from pandas.tests.extension.conftest import (  # noqa: F401
+        as_array,  # noqa: F401
+        use_numpy,  # noqa: F401
+        groupby_apply_op,  # noqa: F401
+        as_frame,  # noqa: F401
+        as_series,  # noqa: F401
+    )
+
 
 FletcherTestType = namedtuple(
     "FletcherTestType",

--- a/tests/test_pandas_integration.py
+++ b/tests/test_pandas_integration.py
@@ -135,7 +135,7 @@ def test_series_attributes():
     s = pd.Series(fr.FletcherArray(TEST_ARRAY))
     assert s.ndim == 1
     assert s.size == 3
-    assert s.base is not None
+    assert s.values is not None
     # This line currently fails with pandas master: https://github.com/pandas-dev/pandas/issues/22414
     assert (s.T == s).all()
     assert s.memory_usage() > 8


### PR DESCRIPTION
pytest>=3.7.0 includes more recent pyflakes detecting F821 (undefined name) in typing comments. 
