### PR TITLE
Modif take with pyarrow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,4 +46,3 @@ workflows:
     jobs:
       - "python-3.6"
       - "python-3.7"
-      - "upstream-dev"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @fjetter @xhochy

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fletcher
 
-[![CircleCI](https://circleci.com/gh/xhochy/fletcher/tree/master.svg?style=svg)](https://circleci.com/gh/xhochy/fletcher/tree/master)
+[![CircleCI](https://circleci.com/gh/krivonogov/fletcher/tree/master.svg?style=svg)](https://circleci.com/gh/krivonogov/fletcher/tree/master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fxhochy%2Ffletcher.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fxhochy%2Ffletcher?ref=badge_shield)
 

--- a/ci/circle_build_linux.sh
+++ b/ci/circle_build_linux.sh
@@ -22,7 +22,7 @@ conda config --add channels https://repo.continuum.io/pkgs/free
 conda config --add channels conda-forge
 
 conda create -y -q -n fletcher python=${PYTHON_VERSION} \
-    pandas pyarrow pytest pytest-cov pytest-flake8 \
+    pandas pyarrow=0.14 pytest pytest-cov pytest-flake8 \
     hypothesis \
     flake8 \
     setuptools_scm \


### PR DESCRIPTION
Modification of the take function so that it stays in PyArrow runtime. This is done using code from ArrayInterface._to_numpy(). Take can now be called with list, arrays and slice. 