### PR TITLE
Support conversion to/from Arrow

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -230,8 +230,7 @@ class FletcherArray(ExtensionArray):
         return self.data.to_pandas().values
 
     def __arrow_array__(self, type=None):
-        # TODO handle type, chunks
-        return self.data.chunk(0)
+        return self.data
 
     @property
     def size(self):

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import six
+from pandas.api.extensions import register_extension_dtype
 from pandas.api.types import (
     is_array_like,
     is_bool_dtype,
@@ -20,7 +21,6 @@ from pandas.api.types import (
 )
 from pandas.core.arrays import ExtensionArray
 from pandas.core.dtypes.dtypes import ExtensionDtype
-from pandas.api.extensions import register_extension_dtype
 
 from ._algorithms import all_op, any_op, extract_isnull_bytemap
 
@@ -188,6 +188,7 @@ class FletcherDtype(ExtensionDtype):
         return FletcherArray
 
     def __from_arrow__(self, array):
+        """Construct a FletcherArray from the pyarrow data."""
         return FletcherArray(array, dtype=self)
 
 
@@ -230,6 +231,7 @@ class FletcherArray(ExtensionArray):
         return self.data.to_pandas().values
 
     def __arrow_array__(self, type=None):
+        """Convert myself to a pyarrow Array or ChunkedArray."""
         return self.data
 
     @property


### PR DESCRIPTION
Trying to incorporate the recent work I have been doing for pandas ExtensionArray roundtrip with pyarrow, as fletcher is a good use case to battle test this.

Very preliminary PR (needs proper implementation, tests, etc), but to showcase, with those changes a roundtrip from a pandas DataFrame with fletcher columns preserves the types now:

```
In [1]: import fletcher as fr 
   ...: import pandas as pd 
   ...:  
   ...: df = pd.DataFrame({ 
   ...:     'str': fr.FletcherArray(['a', 'b', 'c']) 
   ...: }) 

In [3]: table = pa.table(df) 

In [4]: table 
Out[4]: 
pyarrow.Table
str: string
metadata
--------
{b'pandas': b'{"index_columns": [{"kind": "range", "name": null, "start": 0, "'
            b'stop": 3, "step": 1}], "column_indexes": [{"name": null, "field_'
            b'name": null, "pandas_type": "unicode", "numpy_type": "object", "'
            b'metadata": {"encoding": "UTF-8"}}], "columns": [{"name": "str", '
            b'"field_name": "str", "pandas_type": "unicode", "numpy_type": "fl'
            b'etcher[string]", "metadata": null}], "creator": {"library": "pya'
            b'rrow", "version": "0.15.1.dev212+g4afe9f0ea.d20191105"}, "pandas'
            b'_version": "0.26.0.dev0+691.g157495696.dirty"}'}

In [5]: df_new = table.to_pandas() 

In [6]: df_new     
Out[6]: 
  str
0   a
1   b
2   c

In [7]: df_new.dtypes   
Out[7]: 
str    fletcher[string]
dtype: object
```

Which should for example also mean that writing / reading parquet preserves the fletcher dtypes.

