### PR TITLE
introduce unique on FletcherArray

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -489,8 +489,9 @@ class FletcherArray(ExtensionArray):
     def copy(self):
         # type: () -> ExtensionArray
         """
-        Return a copy of the array
-        currently is a shadow copy - pyarrow array are supposed to be immutable
+        Return a copy of the array.
+
+        Currently is a shadow copy - pyarrow array are supposed to be immutable.
 
         Returns
         -------
@@ -738,13 +739,18 @@ class FletcherArray(ExtensionArray):
     def unique(self):
         """
         Compute the ExtensionArray of unique values.
-        It completely relies on the Pyarrow.ChunkedArray.unique
+
+        It relies on the Pyarrow.ChunkedArray.unique and if
+        it fails, comes back to the naive implementation.
 
         Returns
         -------
         uniques : ExtensionArray
         """
-        return type(self)(self.data.unique())
+        try:
+            return type(self)(self.data.unique())
+        except NotImplementedError:
+            return super().unique()
 
 
 def pandas_from_arrow(

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -486,22 +486,16 @@ class FletcherArray(ExtensionArray):
         """
         return extract_isnull_bytemap(self.data)
 
-    def copy(self, deep=False):
-        # type: (bool) -> ExtensionArray
+    def copy(self):
+        # type: () -> ExtensionArray
         """
-        Return a copy of the array.
-
-        Parameters
-        ----------
-        deep : bool, default False
-            Also copy the underlying data backing this array.
+        Return a copy of the array
+        currently is a shadow copy - pyarrow array are supposed to be immutable
 
         Returns
         -------
         ExtensionArray
         """
-        if deep:
-            raise NotImplementedError("Deep copy is not supported")
         return type(self)(self.data)
 
     @property
@@ -740,6 +734,17 @@ class FletcherArray(ExtensionArray):
         # the data, before passing to take.
         result = take(data, indices, fill_value=fill_value, allow_fill=allow_fill)
         return self._from_sequence(result, dtype=self.data.type)
+
+    def unique(self):
+        """
+        Compute the ExtensionArray of unique values.
+        It completely relies on the Pyarrow.ChunkedArray.unique
+
+        Returns
+        -------
+        uniques : ExtensionArray
+        """
+        return type(self)(self.data.unique())
 
 
 def pandas_from_arrow(

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -393,11 +393,6 @@ class TestBaseMethodsTests(BaseMethodsTests):
                 self, data_for_grouping, na_sentinel
             )
 
-    @pytest.mark.parametrize("box", [pd.Series, lambda x: x])
-    @pytest.mark.parametrize("method", [lambda x: x.unique(), pd.unique])
-    def test_unique(self, data, box, method):
-        BaseMethodsTests.test_unique(self, data, box, method)
-
     def test_searchsorted(self, data_for_sorting, as_series):  # noqa: F811
         if pa.types.is_boolean(data_for_sorting.dtype.arrow_dtype):
             pytest.skip("Boolean has too few values for this test")

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -393,6 +393,11 @@ class TestBaseMethodsTests(BaseMethodsTests):
                 self, data_for_grouping, na_sentinel
             )
 
+    @pytest.mark.parametrize("box", [pd.Series, lambda x: x])
+    @pytest.mark.parametrize("method", [lambda x: x.unique(), pd.unique])
+    def test_unique(self, data, box, method):
+        BaseMethodsTests.test_unique(self, data, box, method)
+
     def test_searchsorted(self, data_for_sorting, as_series):  # noqa: F811
         if pa.types.is_boolean(data_for_sorting.dtype.arrow_dtype):
             pytest.skip("Boolean has too few values for this test")

--- a/tests/test_pandas_integration.py
+++ b/tests/test_pandas_integration.py
@@ -173,6 +173,17 @@ def test_factorize():
     npt.assert_array_equal(uniques, expected_uniques)
 
 
+def test_unique():
+    arr = fr.FletcherArray(TEST_ARRAY)
+    uniques = arr.unique()
+    expected_uniques = pd.unique(arr.astype(object))
+
+    assert isinstance(uniques, fr.FletcherArray)
+
+    uniques = uniques.astype(object)
+    npt.assert_array_equal(uniques, expected_uniques)
+
+
 def test_groupby():
     arr = fr.FletcherArray(["a", "a", "b", None])
     df = pd.DataFrame({"str": arr, "int": [10, 5, 24, 6]})


### PR DESCRIPTION
* introduce unique on FletcherArray
* using only true copy that's required by ExtensionArray

This solves issue https://github.com/xhochy/fletcher/issues/25. We define `self.unique()` using `pyarrow.unique()` and add some tests for this function. Also we remove the boolean `deep` in `self.copy()` as it is not needed in pandas' specification of ExtensionArray.