### PR TITLE
Modification of take and getitem so that it stays in pyarrow runtime.

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -686,7 +686,6 @@ class FletcherArray(ExtensionArray):
 
     @property
     def _indices_dtype(self):
-
         """
         Return the correct DataType for an array of indices of an ExtensionArray.
 

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
+from collections import OrderedDict
 from typing import Any, Optional, Sequence, Tuple, Union
 
 import numpy as np

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -429,17 +429,16 @@ class FletcherArray(ExtensionArray):
         """
         if is_integer(item):
             return self.data[item].as_py()
-        if (
-            not isinstance(item, slice)
-            and len(item) > 0
-            and np.asarray(item[:1]).dtype.kind == "b"
-        ):
-            item = np.argwhere(item).flatten()
-        elif isinstance(item, slice):
+        if isinstance(item, slice):
             if item.step == 1 or item.step is None:
                 return FletcherArray(self.data[item])
             else:
                 item = np.arange(len(self), dtype=self._indices_dtype)[item]
+        elif (
+            len(item) > 0
+            and is_bool_dtype(item) 
+        ):
+            item = np.argwhere(item).flatten()
         return self.take(item)
 
     def isna(self):

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -3,21 +3,13 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
-from collections import OrderedDict
 from typing import Any, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import six
-from pandas.api.types import is_array_like, is_bool_dtype, is_integer
-from pandas.api.types import (
-    is_array_like,
-    is_bool_dtype,
-    is_int64_dtype,
-    is_integer,
-    is_integer_dtype,
-)
+from pandas.api.types import is_array_like, is_bool_dtype, is_int64_dtype, is_integer
 from pandas.core.arrays import ExtensionArray
 from pandas.core.dtypes.dtypes import ExtensionDtype
 from pandas.core.indexers import validate_indices
@@ -693,11 +685,12 @@ class FletcherArray(ExtensionArray):
 
     @property
     def _indices_dtype(self):
-        """
-        Return the correct DataType for an array of indices of an ExtensionArray, either int32 or int64
-        depending on the length.
-        """
 
+        """
+        Return the correct DataType for an array of indices of an ExtensionArray.
+
+        The Datatype is either int32 or int64 depending on the length.
+        """
         # this is the right bound because the last element of self is at position len(self)-1
         return np.dtype(
             np.int32() if len(self) <= np.iinfo(np.int32()).max + 1 else np.int64()

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -4,13 +4,13 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 from collections import OrderedDict
-from collections.abc import Iterable
 from typing import Any, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import six
+from pandas.api.types import is_array_like, is_bool_dtype, is_integer
 from pandas.api.types import (
     is_array_like,
     is_bool_dtype,
@@ -20,6 +20,8 @@ from pandas.api.types import (
 )
 from pandas.core.arrays import ExtensionArray
 from pandas.core.dtypes.dtypes import ExtensionDtype
+from pandas.core.indexers import validate_indices
+from pandas.core.sorting import get_group_index_sorter
 
 from ._algorithms import all_op, any_op, extract_isnull_bytemap
 
@@ -432,50 +434,20 @@ class FletcherArray(ExtensionArray):
         For a boolean mask, return an instance of ``ExtensionArray``, filtered
         to the values where ``item`` is True.
         """
-        # Workaround for Arrow bug that segfaults on empty slice.
-        # This is fixed in Arrow master, will be released in 0.10
-        if isinstance(item, slice):
-            start = item.start or 0
-            stop = item.stop if item.stop is not None else len(self.data)
-            stop = min(stop, len(self.data))
-            step = item.step if item.step is not None else 1
-            # Arrow can't handle slices with steps other than 1
-            # https://issues.apache.org/jira/browse/ARROW-2714
-            if step != 1:
-                arr = np.asarray(self)[item]
-                # ARROW-2806: Inconsistent handling of np.nan requires adding a mask
-                if pa.types.is_integer(self.dtype.arrow_dtype) or pa.types.is_floating(
-                    self.dtype.arrow_dtype
-                ):
-                    mask = pd.isna(arr)
-                else:
-                    mask = None
-                return type(self)(pa.array(arr, type=self.dtype.arrow_dtype, mask=mask))
-            if stop - start == 0:
-                return type(self)(pa.array([], type=self.data.type))
-        elif isinstance(item, Iterable):
-            if not is_array_like(item):
-                item = np.array(item)
-            if is_integer_dtype(item):
-                return self.take(item)
-            elif is_bool_dtype(item):
-                indices = np.array(item)
-                indices = np.argwhere(indices).flatten()
-                return self.take(indices)
+        if is_integer(item):
+            return self.data[item].as_py()
+        if (
+            not isinstance(item, slice)
+            and len(item) > 0
+            and np.asarray(item[:1]).dtype.kind == "b"
+        ):
+            item = np.argwhere(item).flatten()
+        elif isinstance(item, slice):
+            if item.step == 1 or item.step is None:
+                return FletcherArray(self.data[item])
             else:
-                raise IndexError(
-                    "Only integers, slices and integer or boolean arrays are valid indices."
-                )
-        elif is_integer(item):
-            if item < 0:
-                item += len(self)
-            if item >= len(self):
-                return None
-        value = self.data[item]
-        if isinstance(value, pa.ChunkedArray):
-            return type(self)(value)
-        else:
-            return value.as_py()
+                item = np.arange(len(self), dtype=self._indices_dtype)[item]
+        return self.take(item)
 
     def isna(self):
         # type: () -> np.ndarray
@@ -516,9 +488,8 @@ class FletcherArray(ExtensionArray):
         return size
 
     @property
-    def base(self):
-        """Return base object of the underlying data."""
-        return self.data
+    def _has_single_chunk(self):
+        return self.data.num_chunks == 1
 
     def factorize(self, na_sentinel=-1):
         # type: (int) -> Tuple[np.ndarray, ExtensionArray]
@@ -549,8 +520,8 @@ class FletcherArray(ExtensionArray):
         -----
         :meth:`pandas.factorize` offers a `sort` keyword as well.
         """
-        if pa.types.is_dictionary(self.data.type):
-            raise NotImplementedError()
+        if self.data.num_chunks == 0:
+            return type(self)(pa.array([], type=self.data.type)).factorize(na_sentinel)
         elif self.data.num_chunks == 1:
             # Dictionaryencode and do the same as above
             encoded = self.data.chunk(0).dictionary_encode()
@@ -564,7 +535,6 @@ class FletcherArray(ExtensionArray):
         else:
             np_array = self.data.to_pandas().values
             return pd.factorize(np_array, na_sentinel=na_sentinel)
-
     def astype(self, dtype, copy=True):
         """
         Cast to a NumPy array with 'dtype'.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -54,3 +54,90 @@ def test_pandas_from_arrow():
 
     table = pa.Table.from_arrays([arr], ["column"])
     pdt.assert_frame_equal(expected_df, fr.pandas_from_arrow(table))
+
+
+def test_take_on_concatenated_chunks():
+    test = [[1, 2, 8, 3], [4, 1, 5, 6], [7, 8, 9]]
+    indices = np.array([4, 2, 8])
+    expected_result = fr.FletcherArray([np.concatenate(test)[e] for e in indices])
+    result = fr.FletcherArray(pa.chunked_array(test))._take_on_concatenated_chunks(
+        indices
+    )
+    npt.assert_array_equal(expected_result, result)
+
+
+def test_take_on_concatenated_chunks_with_many_chunks():
+    test = [[1, 2, 3] for _ in range(100)]
+    fr_test = fr.FletcherArray(pa.chunked_array(test))
+    indices1 = np.array([(30 * k + (k % 3)) for k in range(0, 10)])
+    indices2 = np.array([2, 5] * 100)
+    for indices in [indices1, indices2]:
+        expected_result = fr.FletcherArray([np.concatenate(test)[e] for e in indices])
+        result = fr_test._take_on_concatenated_chunks(indices)
+        npt.assert_array_equal(expected_result, result)
+
+
+def test_take_on_chunks():
+    test = [[1, 2, 8, 3], [4, 1, 5, 6], [7, 8, 9]]
+    indices = np.array([2, 4, 8])
+    limits_idx = np.array([0, 1, 2, 3])
+    cum_lengths = np.array([0, 4, 8])
+    expected_result = fr.FletcherArray([np.concatenate(test)[e] for e in indices])
+    result = fr.FletcherArray(pa.chunked_array(test))._take_on_chunks(
+        indices, limits_idx=limits_idx, cum_lengths=cum_lengths
+    )
+    npt.assert_array_equal(expected_result, result)
+
+
+def test_take_on_chunks_with_many_chunks():
+    test = [[1, 2, 3] for _ in range(100)]
+    fr_test = fr.FletcherArray(pa.chunked_array(test))
+
+    indices1 = np.array([(30 * k + (k % 3)) for k in range(0, 10)])
+    # bins will be already sorted
+    indices2 = np.array([2, 5] * 100)
+    # bins will have to be sorted
+
+    limits_idx1 = np.array([0] + [k // 10 for k in range(10, 110)])
+    limits_idx2 = np.array([0] + [100] + [200] * 99)
+
+    sort_idx1 = None
+    sort_idx2 = np.array(
+        [2 * k for k in range(0, 100)] + [2 * k + 1 for k in range(100)]
+    )
+
+    indices2 = indices2[sort_idx2]
+
+    cum_lengths = np.array([3 * k for k in range(100)])
+
+    for indices, limits_idx, cum_lengths, sort_idx in [
+        (indices1, limits_idx1, cum_lengths, sort_idx1),
+        (indices2, limits_idx2, cum_lengths, sort_idx2),
+    ]:
+        expected_result = fr.FletcherArray([np.concatenate(test)[e] for e in indices])
+        result = fr_test._take_on_chunks(
+            indices, limits_idx=limits_idx, cum_lengths=cum_lengths, sort_idx=sort_idx
+        )
+        npt.assert_array_equal(expected_result, result)
+
+
+def test_indices_dtype():
+    arr1 = fr.FletcherArray(np.zeros(np.iinfo(np.int32()).max + 1))
+    arr2 = fr.FletcherArray(np.zeros(np.iinfo(np.int32()).max + 2))
+    for arr in [arr1, arr2]:
+        npt.assert_equal(
+            len(arr) - 1, np.array([len(arr) - 1], dtype=arr._indices_dtype)[0]
+        )
+    npt.assert_equal(arr1._indices_dtype, np.dtype(np.int32))
+    npt.assert_equal(arr2._indices_dtype, np.dtype(np.int64))
+
+
+def test_take():
+    test = [[1, 2, 8, 3], [4, 1, 5, 6], [7, 8, 9]]
+    indices = [4, 2, 8] * 100
+    fr_test = fr.FletcherArray(pa.chunked_array(test))
+    result = fr_test.take(indices)
+    expected_result = fr.FletcherArray(
+        pa.chunked_array([[4, 8, 7] for _ in range(100)])
+    )
+    npt.assert_array_equal(expected_result, result)


### PR DESCRIPTION
In this PR, I tackle the issue https://github.com/xhochy/fletcher/issues/22.  I modify the `take` function so that it stays in pyarrow runtime, this is done using `pyarrow.take()`. I also modify `__getitem__` so that is uses `pyarrow.__getitem__()` as often as possible and falls back to `self.take` otherwise.

I had two possibilities for `take`, either concatenate the `FletcherArray` and apply `pyarrow.take()` or apply `pyarrow.take()` on each chunk using `self._get_chunk_indexer` to split `indices` with respect to each chunk. After doing some benchmarks, it turns out that if the ratio `len(self) / len(indices)` is bigger than 0.3, it is better to concatenate first. Here are the benchmarks for time and memory:
![image](https://user-images.githubusercontent.com/49305743/68786670-79d69100-0640-11ea-8dd1-e6870b952390.png)
![image](https://user-images.githubusercontent.com/49305743/68786707-8529bc80-0640-11ea-9ea0-aa457614cdc1.png)
![image](https://user-images.githubusercontent.com/49305743/68786720-8ce96100-0640-11ea-9060-d7638d2a0022.png)
![image](https://user-images.githubusercontent.com/49305743/68786731-91157e80-0640-11ea-88ea-1f5a4eb7b284.png)


Finally, I introduce `self._has_single_chunk()` for more clarity and I had to treat the special case `self.data.num_chunks == 0` in self.factorize() so that tests won't break with the new `__getitem__`.
