### PR TITLE
Implement take for continuous arrays

### DIFF
--- a/benchmarks/take.py
+++ b/benchmarks/take.py
@@ -1,0 +1,94 @@
+import itertools
+from functools import partialmethod
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+
+import fletcher as fr
+
+
+def _take_nofill_range(self, attr_name: str) -> None:
+    attr = getattr(self, attr_name)
+    attr.take(np.arange(len(attr) / 2))
+
+
+def _take_nofill_random(self, attr_name: str) -> None:
+    attr = getattr(self, attr_name)
+    attr.take(self.data_small)
+
+
+def _take_nofill_random_negative(self, attr_name: str) -> None:
+    attr = getattr(self, attr_name)
+    attr.take(-self.data_small)
+
+
+# TODO: How is this trigged? pd.Series.take doesn't have a fill_value parameter
+def _take_fill_random(self, attr_name: str) -> None:
+    attr = getattr(self, attr_name)
+    attr.take(self.data_small_missing, allow_fill=True, fill_value=attr[0])
+
+
+class Take:
+    def setup(self):
+        np.random.seed(93487)
+        # TODO: Is it maybe faster to separate each type into its own Take* class?
+        #       It seems like the data is regenerated for each benchmark and thus
+        #       is quite some overhead here.
+        self.data = np.random.randint(0, 2 ** 20, size=2 ** 24)
+        self.pd_int = pd.Series(self.data)
+        self.fr_cont_int = pd.Series(fr.FletcherContinuousArray(self.data))
+        chunked_data = pa.chunked_array(
+            [
+                pa.array(self.data[0 : len(self.data) // 2]),
+                pa.array(self.data[len(self.data) // 2 : -1]),
+            ]
+        )
+        self.fr_chunked_int = pd.Series(fr.FletcherChunkedArray(chunked_data))
+
+        mask = np.random.rand(2 ** 24) > 0.8
+        self.pd_int_na = pd.Series(pd.arrays.IntegerArray(self.data, mask))
+        self.fr_cont_int_na = pd.Series(
+            fr.FletcherContinuousArray(pa.array(self.data, mask=mask))
+        )
+        self.fr_chunked_int_na = pd.Series(
+            fr.FletcherChunkedArray(pa.array(self.data, mask=mask))
+        )
+
+        self.data_small = np.random.randint(0, 2 ** 16, size=2 ** 18)
+        self.data_small_missing = self.data_small.copy()
+        self.data_small_missing[0:-1:2] = -1
+        data_small_str = self.data_small.astype(str)
+        self.pd_str = pd.Series(data_small_str)
+        self.fr_cont_str = pd.Series(fr.FletcherContinuousArray(data_small_str))
+        data_small_str_chunked = pa.chunked_array(
+            [
+                pa.array(data_small_str[0 : len(data_small_str) // 2]),
+                pa.array(data_small_str[len(data_small_str) // 2 : -1]),
+            ]
+        )
+        self.fr_chunked_str = pd.Series(fr.FletcherChunkedArray(data_small_str_chunked))
+
+
+# Auto-generate benchmark methods
+attrs = [
+    "pd_int",
+    "fr_cont_int",
+    "fr_chunked_int",
+    "pd_int_na",
+    "fr_cont_int_na",
+    "fr_chunked_int_na",
+    "pd_str",
+    "fr_cont_str",
+    "fr_chunked_str",
+]
+functions = {
+    "take_nofill_range": _take_nofill_range,
+    "take_nofill_random": _take_nofill_random,
+    "take_nofill_random_negative": _take_nofill_random_negative,
+    # "take_fill_random": _take_fill_random,
+}
+
+for attr, func in itertools.product(attrs, functions.items()):
+    fname, call = func
+    setattr(Take, f"time_{fname}_{attr}", partialmethod(call, attr_name=attr))

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -514,6 +514,125 @@ class FletcherBaseArray(ExtensionArray):
         except NotImplementedError:
             return super().unique()
 
+    def _pd_object_take(
+        self,
+        indices: Union[Sequence[int], np.ndarray],
+        allow_fill: bool = False,
+        fill_value: Optional[Any] = None,
+    ) -> ExtensionArray:
+        """Run take using object dtype and pandas' built-in algorithm.
+
+        This is slow and should be avoided in future but is kept here as not all
+        special cases are yet supported.
+        """
+        from pandas.core.algorithms import take
+
+        data = self.astype(object)
+        if allow_fill and fill_value is None:
+            fill_value = self.dtype.na_value
+        # fill value should always be translated from the scalar
+        # type for the array, to the physical storage type for
+        # the data, before passing to take.
+        result = take(data, indices, fill_value=fill_value, allow_fill=allow_fill)
+        return self._from_sequence(result, dtype=self.data.type)
+
+    def _take_array(
+        self,
+        array: pa.Array,
+        indices: Union[Sequence[int], np.ndarray],
+        allow_fill: bool = False,
+        fill_value: Optional[Any] = None,
+    ) -> ExtensionArray:
+        """
+        Take elements from a pyarrow.Array.
+
+        Parameters
+        ----------
+        indices : sequence of integers
+            Indices to be taken.
+        allow_fill : bool, default False
+            How to handle negative values in `indices`.
+            * False: negative values in `indices` indicate positional indices
+              from the right (the default). This is similar to
+              :func:`numpy.take`.
+            * True: negative values in `indices` indicate
+              missing values. These values are set to `fill_value`. Any other
+              other negative values raise a ``ValueError``.
+        fill_value : any, optional
+            Fill value to use for NA-indices when `allow_fill` is True.
+            This may be ``None``, in which case the default NA value for
+            the type, ``self.dtype.na_value``, is used.
+            For many ExtensionArrays, there will be two representations of
+            `fill_value`: a user-facing "boxed" scalar, and a low-level
+            physical NA value. `fill_value` should be the user-facing version,
+            and the implementation should handle translating that to the
+            physical version for processing the take if nescessary.
+
+        Returns
+        -------
+        ExtensionArray
+
+        Raises
+        ------
+        IndexError
+            When the indices are out of bounds for the array.
+        ValueError
+            When `indices` contains negative values other than ``-1``
+            and `allow_fill` is True.
+
+        Notes
+        -----
+        ExtensionArray.take is called by ``Series.__getitem__``, ``.loc``,
+        ``iloc``, when `indices` is a sequence of values. Additionally,
+        it's called by :meth:`Series.reindex`, or any other method
+        that causes realignemnt, with a `fill_value`.
+
+        See Also
+        --------
+        numpy.take
+        pandas.api.extensions.take
+        """
+        if isinstance(indices, pa.Array) and pa.types.is_integer(indices):
+            # TODO: handle allow_fill, fill_value
+            if allow_fill or fill_value is not None:
+                raise NotImplementedError(
+                    "Cannot use allow_fill or fill_value with a pa.Array"
+                )
+            indices_array = indices
+        elif isinstance(indices, Iterable):
+            # Why is np.ndarray inferred as Iterable[Any]?
+            if len(indices) == 0:  # type: ignore
+                return type(self)(pa.array([], type=array.type))
+            elif not is_array_like(indices):
+                indices = np.array(indices)
+            if not is_integer_dtype(indices):
+                raise ValueError("Only integer dtyped indices are supported")
+            # TODO: handle fill_value
+            mask = indices < 0
+            if allow_fill and indices.min() < -1:
+                raise ValueError(
+                    "Invalid value in 'indices'. Must be between -1 "
+                    "and the length of the array."
+                )
+            if len(self) == 0 and (~mask).any():
+                raise IndexError("cannot do a non-empty take")
+            if indices.max() >= len(self):
+                raise IndexError("out of bounds value in 'indices'.")
+            if not allow_fill:
+                indices[mask] = len(array) + indices[mask]
+                mask = None
+            elif not pd.isna(fill_value):
+                # TODO: Needs fillna on pa.Array
+                return self._pd_object_take(
+                    indices, allow_fill=True, fill_value=fill_value
+                )
+            indices_array = pa.array(indices, mask=mask)
+        elif is_array_like(indices) and len(indices) == 0:
+            indices_array = pa.array([], type=pa.int64())
+        else:
+            raise NotImplementedError(f"take is not implemented for {type(indices)}")
+        return type(self)(array.take(indices_array))
+
 
 class FletcherContinuousArray(FletcherBaseArray):
     """Pandas ExtensionArray implementation backed by Apache Arrow's pyarrow.Array."""
@@ -884,28 +1003,6 @@ class FletcherContinuousArray(FletcherBaseArray):
             new_values = self.copy()
         return new_values
 
-    def _pd_object_take(
-        self,
-        indices: Union[Sequence[int], np.ndarray],
-        allow_fill: bool = False,
-        fill_value: Optional[Any] = None,
-    ) -> ExtensionArray:
-        """Run take using object dtype and pandas' built-in algorithm.
-
-        This is slow and should be avoided in future but is kept here as not all
-        special cases are yet supported.
-        """
-        from pandas.core.algorithms import take
-
-        data = self.astype(object)
-        if allow_fill and fill_value is None:
-            fill_value = self.dtype.na_value
-        # fill value should always be translated from the scalar
-        # type for the array, to the physical storage type for
-        # the data, before passing to take.
-        result = take(data, indices, fill_value=fill_value, allow_fill=allow_fill)
-        return self._from_sequence(result, dtype=self.data.type)
-
     def take(
         self,
         indices: Union[Sequence[int], np.ndarray],
@@ -961,46 +1058,7 @@ class FletcherContinuousArray(FletcherBaseArray):
         numpy.take
         pandas.api.extensions.take
         """
-        if isinstance(indices, pa.Array) and pa.types.is_integer(indices):
-            # TODO: handle allow_fill, fill_value
-            if allow_fill or fill_value is not None:
-                raise NotImplementedError(
-                    "Cannot use allow_fill or fill_value with a pa.Array"
-                )
-            indices_array = indices
-        elif isinstance(indices, Iterable):
-            # Why is np.ndarray inferred as Iterable[Any]?
-            if len(indices) == 0:  # type: ignore
-                return type(self)(pa.array([], type=self.data.type))
-            elif not is_array_like(indices):
-                indices = np.array(indices)
-            if not is_integer_dtype(indices):
-                raise ValueError("Only integer dtyped indices are supported")
-            # TODO: handle fill_value
-            mask = indices < 0
-            if allow_fill and indices.min() < -1:
-                raise ValueError(
-                    "Invalid value in 'indices'. Must be between -1 "
-                    "and the length of the array."
-                )
-            if len(self) == 0 and (~mask).any():
-                raise IndexError("cannot do a non-empty take")
-            if indices.max() >= len(self):
-                raise IndexError("out of bounds value in 'indices'.")
-            if not allow_fill:
-                indices[mask] = len(self.data) + indices[mask]
-                mask = None
-            elif not pd.isna(fill_value):
-                # TODO: Needs fillna on pa.Array
-                return self._pd_object_take(
-                    indices, allow_fill=True, fill_value=fill_value
-                )
-            indices_array = pa.array(indices, mask=mask)
-        elif is_array_like(indices) and len(indices) == 0:
-            indices_array = pa.array([], type=pa.int64())
-        else:
-            raise NotImplementedError(f"take is not implemented for {type(indices)}")
-        return type(self)(self.data.take(indices_array))
+        return self._take_array(self.data, indices, allow_fill, fill_value)
 
 
 class FletcherChunkedArray(FletcherBaseArray):
@@ -1463,6 +1521,9 @@ class FletcherChunkedArray(FletcherBaseArray):
         numpy.take
         pandas.api.extensions.take
         """
+        if self.data.num_chunks == 1:
+            return self._take_array(self.data.chunk(0), indices, allow_fill, fill_value)
+
         from pandas.core.algorithms import take
 
         data = self.astype(object)

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -881,8 +881,12 @@ class FletcherContinuousArray(FletcherBaseArray):
             new_values = self.copy()
         return new_values
 
-    def take(self, indices, allow_fill=False, fill_value=None):
-        # type: (Sequence[int], bool, Optional[Any]) -> ExtensionArray
+    def take(
+        self,
+        indices: Union[Sequence[int], np.ndarray],
+        allow_fill: bool = False,
+        fill_value: Optional[Any] = None,
+    ) -> ExtensionArray:
         """
         Take elements from an array.
 
@@ -1349,8 +1353,12 @@ class FletcherChunkedArray(FletcherBaseArray):
             new_values = self.copy()
         return new_values
 
-    def take(self, indices, allow_fill=False, fill_value=None):
-        # type: (Sequence[int], bool, Optional[Any]) -> ExtensionArray
+    def take(
+        self,
+        indices: Union[Sequence[int], np.ndarray],
+        allow_fill: bool = False,
+        fill_value: Optional[Any] = None,
+    ) -> ExtensionArray:
         """
         Take elements from an array.
 

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -72,7 +72,7 @@ class TextAccessor:
 
         if isinstance(na, bool):
             result = np.zeros(len(self.data), dtype=np.bool)
-            na_arg = np.bool_(na)
+            na_arg: Any = np.bool_(na)
 
         else:
             result = np.zeros(len(self.data), dtype=np.uint8)


### PR DESCRIPTION
This improves the take performance of continuous arrays so that it performs similar to the `take` implementation of `pd.Series` based on `np.ndarray` with native datatypes. For chunked arrays, we still will either need a better Take kernel in Arrow or #91 .