### PR TITLE
Also build on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
     linux:


### PR DESCRIPTION
Currently we only build on pull request and thus are sometimes missing the coverage statistics in PRs.