### PR TITLE
Ignore deadline for str-hypothesis tests

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from typing import Optional
 
 import hypothesis.strategies as st
@@ -34,7 +33,7 @@ def _fr_series_from_data(data, fletcher_variant, dtype=pa.string()):
     return pd.Series(fr_array)
 
 
-@settings(deadline=timedelta(milliseconds=1000))
+@settings(deadline=None)
 @given(data=st.lists(st.one_of(st.text(), st.none())))
 def test_text_cat(data, fletcher_variant, fletcher_variant_2):
     if any("\x00" in x for x in data if x):
@@ -144,7 +143,7 @@ def _optional_len(x: Optional[str]) -> int:
         return 0
 
 
-@settings(deadline=timedelta(milliseconds=1000))
+@settings(deadline=None)
 @given(data=st.lists(st.one_of(st.text(), st.none())))
 def test_text_zfill(data, fletcher_variant):
     if any("\x00" in x for x in data if x):


### PR DESCRIPTION
These tests run sometimes a tiny bit more than a second under CPU load. That's fine, don't fail them for that.