### PR TITLE
Work-around for testing of arithmetic operations

### DIFF
--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -1,4 +1,5 @@
 import datetime
+import platform
 import string
 from collections import namedtuple
 from distutils.version import LooseVersion
@@ -862,8 +863,11 @@ class TestBaseArithmeticOpsTests(BaseArithmeticOpsTests):
 
     @skip_non_artithmetic_type
     def test_arith_series_with_array(self, data, all_arithmetic_operators):
+        # On Windows the type of the result when performing arithmetic operations on series with array is the
+        # same as the data type of the input data, but it's int64 when the data is scalar (see method _check_op above),
+        # so we work-around this by converting the data to int64
         BaseArithmeticOpsTests.test_arith_series_with_array(
-            self, data, all_arithmetic_operators
+            self, data.astype(np.int64) if platform.system() == 'Windows' else data, all_arithmetic_operators
         )
 
     @skip_non_artithmetic_type

--- a/tests/test_pandas_extension.py
+++ b/tests/test_pandas_extension.py
@@ -865,9 +865,11 @@ class TestBaseArithmeticOpsTests(BaseArithmeticOpsTests):
     def test_arith_series_with_array(self, data, all_arithmetic_operators):
         # On Windows the type of the result when performing arithmetic operations on series with array is the
         # same as the data type of the input data, but it's int64 when the data is scalar (see method _check_op above),
-        # so we work-around this by converting the data to int64
+        # so we work-around this by converting the data to int64.
         BaseArithmeticOpsTests.test_arith_series_with_array(
-            self, data.astype(np.int64) if platform.system() == 'Windows' else data, all_arithmetic_operators
+            self,
+            data.astype(np.int64) if platform.system() == "Windows" else data,
+            all_arithmetic_operators,
         )
 
     @skip_non_artithmetic_type


### PR DESCRIPTION
Changed test_arith_series_with_array function to convert the data to int64, when running on Windows.