### PR TITLE
User friendly string accessor

### DIFF
--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -246,44 +246,74 @@ def _missing_capactiy(capacity):
     return int(math.ceil(capacity / 8))
 
 
+class TextAccessorBase:
+    """Base class for ``.fr_str`` and ``.fr_strx`` accessors."""
+
+    def __init__(self, obj):
+        self.obj = obj
+        self.data = self.obj.values.data
+
+    def _series_like(self, array: Union[pa.Array, pa.ChunkedArray]) -> pd.Series:
+        """Return an Arrow result as a series with the same base classes as the input."""
+        return pd.Series(
+            type(self.obj.values)(array),
+            dtype=type(self.obj.dtype)(array.type),
+            index=self.obj.index,
+        )
+
+    def _call_str_accessor(self, func, *args, **kwargs) -> pd.Series:
+        """Call the str accessor function with transforming the Arrow series to pandas series
+         and back."""
+        pd_series = self.data.to_pandas()
+        array = pa.array(getattr(pd_series.str, func)(*args, **kwargs).values)
+        return self._series_like(array)
+
+    def _wrap_str_accessor(self, func):
+        """Return a str accessor function that includes the transformation from Arrow series
+        to pandas series and back."""
+
+        def _wrapped_str_fn(*args, **kwargs) -> pd.Series:
+            pd_series = self.data.to_pandas()
+            array = pa.array(getattr(pd_series.str, func)(*args, **kwargs).values)
+            return self._series_like(array)
+
+        return _wrapped_str_fn
+
+    @staticmethod
+    def _validate_str_accessor(func):
+        """Raise an exception if the given function name is not a valid function of StringMethods."""
+        if not (
+            hasattr(pd.core.strings.StringMethods, func)
+            and callable(getattr(pd.core.strings.StringMethods, func))
+        ):
+            raise AttributeError(
+                f"{func} not available in pd.core.strings.StringMethods nor in fletcher.string_array.TextAccessor"
+            )
+
+
 @pd.api.extensions.register_series_accessor("fr_str")
-class TextAccessorExt:
+class TextAccessorExt(TextAccessorBase):
+    """Accessor for pandas exposed as ``.fr_str``."""
+
     def __init__(self, obj):
         """Accessor for pandas exposed as ``.fr_str``.
         fletcher functionality will be used if available otherwise dt functions are invoked."""
         if not isinstance(obj.values, FletcherBaseArray):
             # call StringMethods to validate the input obj
             StringMethods(obj)
-        self.obj = obj
+        super().__init__(obj)
 
-    def __getattribute__(self, name):
-        obj = object.__getattribute__(self, "obj")
-        if not (
-            hasattr(pd.core.strings.StringMethods, name)
-            and callable(getattr(pd.core.strings.StringMethods, name))
-        ):
-            raise AttributeError(
-                f"{name} not available in pd.core.strings.StringMethods nor in fletcher.string_array.TextAccessor"
-            )
-        if isinstance(obj.values, FletcherBaseArray):
+    def __getattr__(self, name):
+        TextAccessorBase._validate_str_accessor(name)
+        if isinstance(self.obj.values, FletcherBaseArray):
             if hasattr(TextAccessor, name) and callable(getattr(TextAccessor, name)):
-                return getattr(TextAccessor(obj), name)
-
-            def _wrapped_str_fn(*args, **kwargs) -> pd.Series:
-                pd_series = obj.values.data.to_pandas()
-                array = pa.array(getattr(pd_series.str, name)(*args, **kwargs).values)
-                return pd.Series(
-                    type(obj.values)(array),
-                    dtype=type(obj.dtype)(array.type),
-                    index=obj.index,
-                )
-
-            return _wrapped_str_fn
-        return getattr(obj.str, name)
+                return getattr(TextAccessor(self.obj), name)
+            return self._wrap_str_accessor(name)
+        return getattr(self.obj.str, name)
 
 
 @pd.api.extensions.register_series_accessor("fr_strx")
-class TextAccessor:
+class TextAccessor(TextAccessorBase):
     """Accessor for pandas exposed as ``.fr_strx``."""
 
     def __init__(self, obj):
@@ -291,9 +321,7 @@ class TextAccessor:
             raise AttributeError(
                 "only Fletcher{Continuous,Chunked}Array[string] has text accessor"
             )
-
-        self.obj = obj
-        self.data = self.obj.values.data
+        super().__init__(obj)
 
     def cat(self, others: Optional[FletcherBaseArray]) -> pd.Series:
         """
@@ -325,20 +353,6 @@ class TextAccessor:
             return pd.Series(
                 FletcherContinuousArray(_text_cat(self.data, others.values.data))
             )
-
-    def _call_str_accessor(self, func, *args, **kwargs) -> pd.Series:
-        pd_series = self.data.to_pandas()
-        return self._series_like(
-            pa.array(getattr(pd_series.str, func)(*args, **kwargs).values)
-        )
-
-    def _series_like(self, array: Union[pa.Array, pa.ChunkedArray]) -> pd.Series:
-        """Return an Arrow result as a series with the same base classes as the input."""
-        return pd.Series(
-            type(self.obj.values)(array),
-            dtype=type(self.obj.dtype)(array.type),
-            index=self.obj.index,
-        )
 
     def contains(self, pat: str, case: bool = True, regex: bool = True) -> pd.Series:
         """

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -272,12 +272,10 @@ class TextAccessorBase:
         """Return a str accessor function that includes the transformation from Arrow series
         to pandas series and back."""
 
-        def _wrapped_str_fn(*args, **kwargs) -> pd.Series:
-            pd_series = self.data.to_pandas()
-            array = pa.array(getattr(pd_series.str, func)(*args, **kwargs).values)
-            return self._series_like(array)
+        def _wrapped_str_accessor(*args, **kwargs) -> pd.Series:
+            return self._call_str_accessor(func, *args, **kwargs)
 
-        return _wrapped_str_fn
+        return _wrapped_str_accessor
 
     @staticmethod
     def _validate_str_accessor(func):

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -295,7 +295,7 @@ class TextAccessorExt(TextAccessorBase):
 
     def __init__(self, obj):
         """Accessor for pandas exposed as ``.fr_str``.
-        fletcher functionality will be used if available otherwise dt functions are invoked."""
+        fletcher functionality will be used if available otherwise str functions are invoked."""
         if not isinstance(obj.values, FletcherBaseArray):
             # call StringMethods to validate the input obj
             StringMethods(obj)

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -245,8 +245,7 @@ def _missing_capactiy(capacity):
     return int(math.ceil(capacity / 8))
 
 
-@pd.api.extensions.register_series_accessor("fr_text")
-@pd.api.extensions.register_series_accessor("text")
+@pd.api.extensions.register_series_accessor("fr_strx")
 class TextAccessor:
     """Accessor for pandas exposed as ``.str``."""
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -202,7 +202,5 @@ def test_fr_str_accessor(fletcher_variant):
         getmodule(ser_fr.fr_str.startswith).__name__ == fr_stringmethods  # type: ignore
     )
     # pandas strings only method
-    assert (
-        getmodule(ser_fr.fr_str._make_accessor).__name__  # type: ignore
-        == pd_stringmethods
-    )
+    s = ser_fr.fr_str.encode("utf8")
+    assert isinstance(s.values, fr.FletcherBaseArray)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -169,9 +169,9 @@ def test_text_zfill(data, fletcher_variant):
     tm.assert_series_equal(result_fr, result_pd)
 
 
-@settings(deadline=None)
-@given(data=st.lists(st.text(min_size=10), min_size=3))
-def test_fr_str_accessor(data):
-    ser_pd = pd.Series(data)
+def test_fr_str_accessor():
+    ser_pd = pd.Series(["a", "b"])
 
-    ser_pd.fr_str
+    ser_pd.fr_str.startswith
+
+    ser_pd.fr_str.split

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -45,7 +45,7 @@ def test_text_cat(data, fletcher_variant, fletcher_variant_2):
     ser_fr_other = _fr_series_from_data(data, fletcher_variant_2)
 
     result_pd = ser_pd.str.cat(ser_pd)
-    result_fr = ser_fr.fr_text.cat(ser_fr_other)
+    result_fr = ser_fr.fr_strx.cat(ser_fr_other)
     result_fr = result_fr.astype(object)
     # Pandas returns np.nan for NA values in cat, keep this in line
     result_fr[result_fr.isna()] = np.nan
@@ -58,7 +58,7 @@ def _check_str_to_bool(func, data, fletcher_variant, *args, **kwargs):
     ser_fr = _fr_series_from_data(data, fletcher_variant)
 
     result_pd = getattr(ser_pd.str, func)(*args, **kwargs)
-    result_fr = getattr(ser_fr.fr_text, func)(*args, **kwargs)
+    result_fr = getattr(ser_fr.fr_strx, func)(*args, **kwargs)
     if result_fr.values.data.null_count > 0:
         result_fr = result_fr.astype(object)
     else:
@@ -97,7 +97,7 @@ def test_contains_no_regex_ascii(data, pat, expected, fletcher_variant):
     for i in range(len(data)):
         ser = fr_series.tail(len(data) - i)
         expected = fr_expected.tail(len(data) - i)
-        result = ser.fr_text.contains(pat, regex=False)
+        result = ser.fr_strx.contains(pat, regex=False)
         tm.assert_series_equal(result, expected)
 
 
@@ -162,8 +162,16 @@ def test_text_zfill(data, fletcher_variant):
     ser_fr = pd.Series(fr_array)
 
     result_pd = ser_pd.str.zfill(max_str_len + 1)
-    result_fr = ser_fr.fr_text.zfill(max_str_len + 1)
+    result_fr = ser_fr.fr_strx.zfill(max_str_len + 1)
     result_fr = result_fr.astype(object)
     # Pandas returns np.nan for NA values in cat, keep this in line
     result_fr[result_fr.isna()] = np.nan
     tm.assert_series_equal(result_fr, result_pd)
+
+
+@settings(deadline=None)
+@given(data=st.lists(st.text(min_size=10), min_size=3))
+def test_fr_str_accessor(data):
+    ser_pd = pd.Series(data)
+
+    ser_pd.fr_str

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -170,8 +170,7 @@ def test_text_zfill(data, fletcher_variant):
     tm.assert_series_equal(result_fr, result_pd)
 
 
-def test_fr_str_accessor(fletcher_variant):
-
+def test_fr_str_accessor(fletcher_array):
     data = ["a", "b"]
     ser_pd = pd.Series(data)
 
@@ -190,11 +189,7 @@ def test_fr_str_accessor(fletcher_variant):
 
     # test fletcher functionality and fallback to pandas
     arrow_data = pa.array(data, type=pa.string())
-    if fletcher_variant == "chunked":
-        fr_array = fr.FletcherChunkedArray(arrow_data)
-    else:
-        fr_array = fr.FletcherContinuousArray(arrow_data)
-
+    fr_array = fletcher_array(arrow_data)
     ser_fr = pd.Series(fr_array)
 
     # method available in both

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,4 +1,3 @@
-from inspect import getmodule
 from typing import Optional
 
 import hypothesis.strategies as st
@@ -174,38 +173,23 @@ def test_fr_str_accessor(fletcher_array):
     data = ["a", "b"]
     ser_pd = pd.Series(data)
 
-    pd_stringmethods = getmodule(pd.core.strings.StringMethods).__name__  # type: ignore
-    fr_stringmethods = getmodule(fr.string_array).__name__  # type: ignore
-
-    # method available in both
-    assert (
-        getmodule(ser_pd.fr_str.startswith).__name__ == pd_stringmethods  # type: ignore
-    )
-    # pandas strings only method
-    assert (
-        getmodule(ser_pd.fr_str._make_accessor).__name__  # type: ignore
-        == pd_stringmethods
-    )
+    # object series is returned
+    s = ser_pd.fr_str.encode("utf8")
+    assert s.dtype == np.dtype("O")
 
     # test fletcher functionality and fallback to pandas
     arrow_data = pa.array(data, type=pa.string())
     fr_array = fletcher_array(arrow_data)
     ser_fr = pd.Series(fr_array)
-
-    # method available in both
-    assert (
-        getmodule(ser_fr.fr_str.startswith).__name__ == fr_stringmethods  # type: ignore
-    )
     # pandas strings only method
     s = ser_fr.fr_str.encode("utf8")
     assert isinstance(s.values, fr.FletcherBaseArray)
 
 
-@pytest.mark.xfail
 def test_fr_str_accessor_fail(fletcher_variant):
 
     data = [1, 2]
     ser_pd = pd.Series(data)
 
-    # this should fail
-    ser_pd.fr_str.startswith
+    with pytest.raises(Exception):
+        ser_pd.fr_str.startswith("a")

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -204,3 +204,13 @@ def test_fr_str_accessor(fletcher_variant):
     # pandas strings only method
     s = ser_fr.fr_str.encode("utf8")
     assert isinstance(s.values, fr.FletcherBaseArray)
+
+
+@pytest.mark.xfail
+def test_fr_str_accessor_fail(fletcher_variant):
+
+    data = [1, 2]
+    ser_pd = pd.Series(data)
+
+    # this should fail
+    ser_pd.fr_str.startswith


### PR DESCRIPTION
Renamed existing TextAccessor from 'fr_text' to 'fr_strx'.
Added an extended TextAccessor 'fr_str' that works with fletcher and object series. If no flechter version of the str function is available, the fletcher series is converted to pandas and back to use the existing pandas implementation as fallback.

Feedback very welcome!