### PR TITLE
run basic test setup on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,26 @@ jobs:
           with:
             token: ${{ secrets.CODECOV_TOKEN }}
             file: ./coverage.xml
+    win:
+      name: "Windows Py${{ matrix.PYTHON_VERSION }}"
+      runs-on: windows-latest
+      env:
+        CI: True
+        PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+      strategy:
+        fail-fast: false
+        matrix:
+          PYTHON_VERSION: ['3.6', '3.7', '3.8']
+      steps:
+        - name: Checkout branch
+          uses: actions/checkout@v2
+        - uses: goanpeca/setup-miniconda@v1
+          with:
+            auto-update-conda: true
+            mamba-version: "*"
+            python-version: ${{ matrix.PYTHON_VERSION }}
+            activate-environment: fletcher
+            environment-file: environment.yml
+            channels: conda-forge
+        - run: python -m pip install -e . --no-build-isolation --no-use-pep517
+        - run: pytest

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -457,7 +457,7 @@ class TextAccessor(TextAccessorBase):
         if to_strip is None:
             to_strip = (
                 " \t\r\n\x1f\x1e\x1d\x1c\x0c\x0b"
-                "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2000\u2009\u200A\u2028\u2029\u202F"
+                "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2000\u2009\u200A\u2028\u2029\u202F\u205F"
             )
         return self._series_like(_text_strip(self.data, to_strip))
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -339,7 +339,7 @@ def test_text_strip_offset(fletcher_variant, fletcher_slice_offset, data):
     + [
         [c]
         for c in " \t\r\n\x1f\x1e\x1d\x1c\x0c\x0b"
-        "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2000\u2009\u200A\u200B\u2028\u2029\u202F"
+        "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2000\u2009\u200A\u200B\u2028\u2029\u202F\u205F"
     ]
     + [[chr(c)] for c in range(0x32)]
     + [[chr(c)] for c in range(0x80, 0x85)]


### PR DESCRIPTION
Adressing #166. This sets up minimal testing on windwos runners without aiming to provide code coverage, using nightlies and testing pre-commit hooks. The goal is to run `pytest` to spot rare issues on widows systems we encoutered last days. Since `fletcher` itself is OS angostic except its dependencies the windows ci job is some kind of optional and not in sync with the linux ci script.

And adds missing white space character of [failed build](https://github.com/xhochy/fletcher/runs/881171847?check_suite_focus=true#step:3:1175).