### PR TITLE
Dictionary and LargeList instantiation

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -62,6 +62,8 @@ _python_type_map = {
     pa.string().id: str,
     # Use any list type here, only LIST is important
     pa.list_(pa.string()).id: list,
+    # Use any large list type here, only LIST is important
+    pa.large_list(pa.string()).id: list,
     # Use any dictionary type here, only dict is important
     pa.dictionary(pa.int32(), pa.int32()).id: dict,
     pa.duration("ns").id: datetime.timedelta,

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -188,6 +188,8 @@ class FletcherBaseDtype(ExtensionDtype):
         """
         if pa.types.is_date(self.arrow_dtype):
             return "O"
+        elif self._is_list:
+            return "O"
         else:
             return np.dtype(self.arrow_dtype.to_pandas_dtype()).kind
 

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -62,6 +62,8 @@ _python_type_map = {
     pa.string().id: str,
     # Use any list type here, only LIST is important
     pa.list_(pa.string()).id: list,
+    # Use any dictionary type here, only dict is important
+    pa.dictionary(pa.int32(), pa.int32()).id: dict,
     pa.duration("ns").id: datetime.timedelta,
 }
 


### PR DESCRIPTION
Right now, we can't instantiate a FletcherArray with a DictionaryArray. For example, the code
```
import fletcher as fr
import pyarrow as pa
 fr.FletcherContinuousArray(pa.array([1,2]).dictionary_encode())
```
fails with `KeyError: 26`, this is the id of the DictionaryArray type in pyarrow and it is missing in the `_python_type_map`.

Same thing with `LargeListArray` when we try to instantiate a `pd.Series`, the code 
```
import pandas as pd 
import fletcher as fr
import pyarrow as pa
pd.Series(fr.FletcherContinuousArray(pa.LargeListArray.from_arrays([1,2], [1,2])))
```
fails with `KeyError: 33` which is the id of the LargeListArray type in pyarrow and it is missing in the `python_type_map`.

Finally the `kind` function in `FletcherBaseDtype` fails for LargeListArrays because the function `to_pandas_dtype` is not implemented for LargeListArrays in pyarrow. We add a small fix to the `kind` function is this PR.