### PR TITLE
[hotfix] Casting item to int in __getitem__ if is_integer is true

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -1019,6 +1019,7 @@ class FletcherContinuousArray(FletcherBaseArray):
                     "Only integers, slices and integer or boolean arrays are valid indices."
                 )
         elif is_integer(item):
+            item = int(item)
             if item < 0:
                 item += len(self)
             if item >= len(self):
@@ -1437,6 +1438,7 @@ class FletcherChunkedArray(FletcherBaseArray):
                     "Only integers, slices and integer or boolean arrays are valid indices."
                 )
         elif is_integer(item):
+            item = int(item)
             if item < 0:
                 item += len(self)
             if item >= len(self):


### PR DESCRIPTION
Right now, one can't use `__getitem__` with a `np.int` when using a `FletcherChunkedArray`. This is because it fails at pyarrow level. More precisely, the following code works fine
```
import pyarrow as pa
import numpy as np
pa.array([1,2])[np.int32(0)]
```
 but this one
```
import pyarrow as pa
import numpy as np
pa.chunked_array(pa.array([1,2]))[np.int32(0)]
```
fails with error `TypeError: key must either be a slice or integer`.
The hotfix provided in this PR is to cast `item` to `int` before applying getitem but maybe this should be fixed directly in pyarrow ?