### PR TITLE
Fast take for list_array with no nulls and numeric type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ Starting with 0.5, we will follow the following versioning scheme:
 * We increase PATCH otherwise.
 
 
-0.6.3 (2020-11-XX)
+0.7.0 (2020-11-XX)
 ------------------
 
 * Add tests for all `str` functions.
 * Fix tests for `pyarrow=0.17.1` and add CI jobs for `0.17.1` and `1.0.1`.
+* Implement a faster take for list arrays.
 
 0.6.2 (2020-10-20)
 ------------------

--- a/fletcher/_algorithms.py
+++ b/fletcher/_algorithms.py
@@ -1,10 +1,10 @@
 from functools import partial
 from typing import Any, Callable, Optional, Union
 
+from numba import prange
 import numpy as np
 import pyarrow as pa
 from pandas.core import nanops
-from numba import prange
 
 from fletcher._compat import njit
 from fletcher.algorithms.utils.chunking import dispatch_chunked_binary_map

--- a/fletcher/_algorithms.py
+++ b/fletcher/_algorithms.py
@@ -1,9 +1,9 @@
 from functools import partial
 from typing import Any, Callable, Optional, Union
 
-from numba import prange
 import numpy as np
 import pyarrow as pa
+from numba import prange
 from pandas.core import nanops
 
 from fletcher._compat import njit

--- a/fletcher/_algorithms.py
+++ b/fletcher/_algorithms.py
@@ -338,6 +338,7 @@ def _merge_valid_bitmaps(a: pa.Array, b: pa.Array) -> np.ndarray:
 
         return result
 
+
 @njit(fastmath=True)
 def _get_new_indptr(self_indptr, indices, new_indptr):
     for i in range(len(indices)):
@@ -387,4 +388,3 @@ def take_on_pyarrow_list(array, indices):
         return pa.ListArray.from_arrays(new_indptr, new_indices)
     else:
         return pa.LargeListArray.from_arrays(new_indptr, new_indices)
-

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -31,6 +31,7 @@ from fletcher._algorithms import (
     skew_op,
     std_op,
     sum_op,
+    take_on_pyarrow_list,
     var_op,
 )
 from fletcher.algorithms.bool import all_op, all_true, any_op, or_na, or_vectorised
@@ -747,6 +748,11 @@ class FletcherBaseArray(StringSupportingExtensionArray):
             indices_array = pa.array(indices, mask=mask)
         elif is_array_like(indices) and len(indices) == 0:
             indices_array = pa.array([], type=pa.int64())
+        elif (self.dtype.is_list
+                and self.data.flatten().null_count == 0
+                and self.data.null_count == 0
+                and self.data.flatten().dtype._is_numeric):
+            return take_on_pyarrow_list(self.data, indices)
         else:
             raise NotImplementedError(f"take is not implemented for {type(indices)}")
         return type(self)(array.take(indices_array))

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -748,10 +748,12 @@ class FletcherBaseArray(StringSupportingExtensionArray):
             indices_array = pa.array(indices, mask=mask)
         elif is_array_like(indices) and len(indices) == 0:
             indices_array = pa.array([], type=pa.int64())
-        elif (self.dtype.is_list
-                and self.data.flatten().null_count == 0
-                and self.data.null_count == 0
-                and self.data.flatten().dtype._is_numeric):
+        elif (
+            self.dtype.is_list
+            and self.data.flatten().null_count == 0
+            and self.data.null_count == 0
+            and self.data.flatten().dtype._is_numeric
+        ):
             return take_on_pyarrow_list(self.data, indices)
         else:
             raise NotImplementedError(f"take is not implemented for {type(indices)}")

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -19,7 +19,7 @@ from fletcher._algorithms import (
     np_ufunc_op,
     prod_op,
     sum_op,
-    take_on_pyarrow_list
+    take_on_pyarrow_list,
 )
 from fletcher.algorithms.utils.chunking import (
     _calculate_chunk_offsets,
@@ -388,6 +388,7 @@ def test_bit_vector_auto(string_builder_variant, data):
             vec.append_false()
     for idx in range(len(data)):
         assert vec.get(idx) == bool(data[idx])
+
 
 @pytest.mark.parametrize(
     ("array", "indices"),

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -19,6 +19,7 @@ from fletcher._algorithms import (
     np_ufunc_op,
     prod_op,
     sum_op,
+    take_on_pyarrow_list
 )
 from fletcher.algorithms.utils.chunking import (
     _calculate_chunk_offsets,
@@ -387,3 +388,39 @@ def test_bit_vector_auto(string_builder_variant, data):
             vec.append_false()
     for idx in range(len(data)):
         assert vec.get(idx) == bool(data[idx])
+
+@pytest.mark.parametrize(
+    ("array", "indices"),
+    [
+        (
+            pa.array([[k] for k in range(10 ** 4)]),
+            np.random.randint(0, 10 ** 4, 10 ** 2),
+        ),
+        (
+            pa.array([[float(k)] for k in range(10 ** 4)]),
+            np.random.randint(0, 10 ** 4, 10 ** 2),
+        ),
+        (
+            pa.array(np.random.randint(0, 100, 10) for _ in range(10 ** 4)),
+            np.random.randint(0, 10 ** 4, 10 ** 5),
+        ),
+        (
+            pa.LargeListArray.from_arrays(
+                [k for k in range(10 ** 4 + 1)], [k for k in range(10 ** 4)]
+            ),
+            np.random.randint(0, 10 ** 4, 10 ** 2),
+        ),
+        (
+            pa.LargeListArray.from_arrays(
+                [k for k in range(10 ** 4 + 1)], [float(k) for k in range(10 ** 4)]
+            ),
+            np.random.randint(0, 10 ** 4, 10 ** 2),
+        ),
+        (pa.array([[]]), [0]),
+    ],
+)
+def test_take_on_pyarrow_list(array, indices):
+    np.testing.assert_array_equal(
+        array.take(pa.array(indices)).to_pylist(),
+        take_on_pyarrow_list(array, indices).to_pylist(),
+    )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -71,3 +71,38 @@ def test_pandas_from_arrow():
     table = pa.Table.from_arrays([arr], ["column"])
     pdt.assert_frame_equal(expected_df, fr.pandas_from_arrow(rb, continuous=True))
     pdt.assert_frame_equal(expected_df, fr.pandas_from_arrow(table, continuous=True))
+
+def test_take_list_arrays():
+    indices = [0, 1, 4, 3, 5]
+    indptr = [0, 2, 3, 5]
+    list_array = pa.ListArray.from_arrays(indptr, indices)
+    large_list_array = pa.LargeListArray.from_arrays(indptr, indices)
+
+    test_with_null = fr.FletcherContinuousArray(pa.array([[1, 2], [None, 3], [4, 5]]))
+
+    assert np.all(
+        pa.array(test_with_null.take([1, 2, 1])).to_pylist()
+        == [[None, 3], [4, 5], [None, 3]]
+    )
+
+    test = fr.FletcherContinuousArray(pa.chunked_array([list_array, list_array])).take([0, 5, 1])
+    test_large = fr.FletcherContinuousArray(
+        pa.chunked_array([large_list_array, large_list_array])
+    ).take([0, 5, 1])
+    expected = [[0, 1], [3, 5], [4]]
+    assert np.all(
+        list(
+            map(
+                lambda x: np.all(np.array(test[x]) == np.array(expected)[x]),
+                range(0, len(test)),
+            )
+        )
+    )
+    assert np.all(
+        list(
+            map(
+                lambda x: np.all(np.array(test_large[x]) == np.array(expected)[x]),
+                range(0, len(test_large)),
+            )
+        )
+    )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -72,6 +72,7 @@ def test_pandas_from_arrow():
     pdt.assert_frame_equal(expected_df, fr.pandas_from_arrow(rb, continuous=True))
     pdt.assert_frame_equal(expected_df, fr.pandas_from_arrow(table, continuous=True))
 
+
 def test_take_list_arrays():
     indices = [0, 1, 4, 3, 5]
     indptr = [0, 2, 3, 5]
@@ -85,7 +86,9 @@ def test_take_list_arrays():
         == [[None, 3], [4, 5], [None, 3]]
     )
 
-    test = fr.FletcherContinuousArray(pa.chunked_array([list_array, list_array])).take([0, 5, 1])
+    test = fr.FletcherContinuousArray(pa.chunked_array([list_array, list_array])).take(
+        [0, 5, 1]
+    )
     test_large = fr.FletcherContinuousArray(
         pa.chunked_array([large_list_array, large_list_array])
     ).take([0, 5, 1])


### PR DESCRIPTION
In this draft PR we test the use of numba and parallelism with ListArrays.

We implemented a fast take on pyarrow.ListArrays with numeric type and no nulls.  
For the benchmark, we used the following code 
```
import pandas as pd

res = pd.DataFrame()

for density in [0.001, 0.01, 0.1, 0.5, 1, 10, 100, 1000]:
    for len_list_array in range(5,10):
        if density * 10**size_list_array <= 10**9:
            values = np.random.randint(0, 10**5, int(density * 10**size_list_array))
            offsets = np.sort(np.random.randint(0, len(values)+1, 10**size_list_array))
            list_array = pa.ListArray.from_arrays(pa.array(offsets), pa.array(values))
            for ratio_ind_length in [0.1 * k for k in range(1, 10)]:

                indices = pa.array(np.random.randint(0, len(list_array), 
                                     int(len(list_array) * ratio_ind_length))
                                 )

                t = time()
                list_array.take(indices)
                t_pyarrow = time() - t

                t = time()
                take_on_pyarrow_list(list_array, np.asarray(indices))
                t_fast = time() - t

                res = res.append({'density': density, 'size_list_array': size_list_array, 
                                    't_pyarrow': t_pyarrow, 't_fast': t_fast, 
                                     'ratio_ind_length': ratio_ind_length}, ignore_index=True)
```
And here are the benchmarks where for each plot the x-axis is the log of the density of the list array (i.e the ratio `len(values) / len(offsets)`) and the y-axis is the ratio of time it takes for pyarrow to perform the `take` operation over our implementation (i.e the ratio `t_pyarrow / t_fast` in our code).
The three rows corresponds to size of the array of indices relatively to the size of the list_array (respectively 30%, 60%, 90%) and the three columns corresponds to the size of the list_array (respectively `10**5, 10**6, 10**7`).
This benchmark was done with `numba.get_num_threads() == 48`.
![2020-08-20-164856_693x694_scrot](https://user-images.githubusercontent.com/49305743/90787539-1bdc8580-e305-11ea-8e39-8f0bc856a5cb.png)


and this one with `numba.get_num_threads() == 4`
![2020-08-20-164524_675x696_scrot](https://user-images.githubusercontent.com/49305743/90787076-a2dd2e00-e304-11ea-83c8-222ba88b181b.png)


We can clearly see that parallelism and numba gives a significant gain of speed compared to the standard implementation, even with only 4 threads we still manage to be at least 3 or 4 times faster. We are very interested in this with @artemru and we would like to know if this is something that will be implemented soon in fletcher or in pyarrow ?  @xhochy 

Thanks !

