### PR TITLE
introducing flatten for FletcherArray

### DIFF
--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -1227,6 +1227,12 @@ class FletcherContinuousArray(FletcherBaseArray):
         """
         return self._take_array(self.data, indices, allow_fill, fill_value)
 
+    def flatten(self):
+        """
+        Flatten the array.
+        """
+        return type(self)(self.data.flatten())
+
 
 class FletcherChunkedArray(FletcherBaseArray):
     """Pandas ExtensionArray implementation backed by Apache Arrow."""
@@ -1662,6 +1668,13 @@ class FletcherChunkedArray(FletcherBaseArray):
         # the data, before passing to take.
         result = take(data, indices, fill_value=fill_value, allow_fill=allow_fill)
         return self._from_sequence(result, dtype=self.data.type)
+
+
+    def flatten(self):
+        """
+        Flatten the array.
+        """
+        return type(self)(pa.chunked_array(ch.flatten() for ch in self.data.iterchunks()))
 
 
 def pandas_from_arrow(

--- a/fletcher/base.py
+++ b/fletcher/base.py
@@ -1669,12 +1669,13 @@ class FletcherChunkedArray(FletcherBaseArray):
         result = take(data, indices, fill_value=fill_value, allow_fill=allow_fill)
         return self._from_sequence(result, dtype=self.data.type)
 
-
     def flatten(self):
         """
         Flatten the array.
         """
-        return type(self)(pa.chunked_array(ch.flatten() for ch in self.data.iterchunks()))
+        return type(self)(
+            pa.chunked_array(ch.flatten() for ch in self.data.iterchunks())
+        )
 
 
 def pandas_from_arrow(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -37,12 +37,17 @@ def test_fletcherarray_constructor():
     with pytest.raises(ValueError):
         fr.FletcherChunkedArray(None)
 
+
 def test_flatten():
-    list_array = pa.array([[1,2], [3,4]])
-    npt.assert_array_equal(fr.FletcherContinuousArray(list_array).flatten(), [1, 2, 3, 4])
+    list_array = pa.array([[1, 2], [3, 4]])
+    npt.assert_array_equal(
+        fr.FletcherContinuousArray(list_array).flatten(), [1, 2, 3, 4]
+    )
 
     chunked_list_array = pa.chunked_array([list_array, list_array])
-    npt.assert_array_equal(fr.FletcherChunkedArray(chunked_list_array).flatten(), [1, 2, 3, 4, 1, 2, 3, 4])
+    npt.assert_array_equal(
+        fr.FletcherChunkedArray(chunked_list_array).flatten(), [1, 2, 3, 4, 1, 2, 3, 4]
+    )
 
 
 def test_pandas_from_arrow():

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -37,6 +37,13 @@ def test_fletcherarray_constructor():
     with pytest.raises(ValueError):
         fr.FletcherChunkedArray(None)
 
+def test_flatten():
+    list_array = pa.array([[1,2], [3,4]])
+    npt.assert_array_equal(fr.FletcherContinuousArray(list_array).flatten(), [1, 2, 3, 4])
+
+    chunked_list_array = pa.chunked_array([list_array, list_array])
+    npt.assert_array_equal(fr.FletcherChunkedArray(chunked_list_array).flatten(), [1, 2, 3, 4, 1, 2, 3, 4])
+
 
 def test_pandas_from_arrow():
     arr = pa.array(["a", "b", "c"], pa.string())


### PR DESCRIPTION
Introducing flatten for `FletcherContinuousArray` and `FletcherChunkedArray` by using `pa.Array.flatten()`. 