### PR TITLE
Add support for string functions returning dataframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Starting with 0.5, we will follow the following versioning scheme:
 
 * Create a shallow copy on `.astype(equal dtype, copy=True)`.
 * Import `pad_1d` only in older `pandas` versions, otherwise use `get_fill_func`
+* Handle `fr_str.extractall` and similar functions correctly, returning a `pd.Dataframe` containing accoring `fletcher` array types.
 
 0.6.0 (2020-09-23)
 ------------------

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -420,6 +420,22 @@ def test_text_extractall(fletcher_variant, data, regex):
     tm.assert_frame_equal(result_pd, result_fr.astype(object))
 
 
+@pytest.mark.parametrize("data", [["123"], ["123+"], ["123+a+", "123+"]])
+@pytest.mark.parametrize("expand", [True, False])
+def test_text_split(fletcher_variant, data, expand):
+
+    ser_fr = _fr_series_from_data(data, fletcher_variant)
+    result_fr = ser_fr.fr_str.split("+", expand=expand)
+
+    ser_pd = pd.Series(data)
+    result_pd = ser_pd.str.split("+", expand=expand)
+
+    if expand:
+        tm.assert_frame_equal(result_pd, result_fr.astype(object))
+    else:
+        tm.assert_series_equal(result_pd, result_fr.astype(object))
+
+
 @settings(deadline=None)
 @given(
     data=st.lists(st.one_of(st.text(), st.none())),

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -405,6 +405,21 @@ def test_fr_str_accessor_fail(fletcher_variant):
         ser_pd.fr_str.startswith("a")
 
 
+@pytest.mark.parametrize("regex", ["([0-9]+)", "([0-9]+)\\+([a-z]+)*"])
+@pytest.mark.parametrize(
+    "data", [["123+"], ["123+a"], ["123+a", "123+"], ["123+", "123+a"]]
+)
+def test_text_extractall(fletcher_variant, data, regex):
+
+    ser_fr = _fr_series_from_data(data, fletcher_variant)
+    result_fr = ser_fr.fr_str.extractall(regex)
+
+    ser_pd = pd.Series(data)
+    result_pd = ser_pd.str.extractall(regex)
+
+    tm.assert_frame_equal(result_pd, result_fr.astype(object))
+
+
 @settings(deadline=None)
 @given(
     data=st.lists(st.one_of(st.text(), st.none())),


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
This PR resolves #192. The fallback mechanism using `str` functions sometimes yields a `pd.Dataframe` (e.g. `extractall`) which will be converted to the accoring `fletcher` types.

Checklist
* [x] Added a `CHANGELOG.md` entry
