### PR TITLE
fixing upcast for fast-take on list

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -96,7 +96,9 @@ def test_take_list_arrays():
     assert np.all(
         list(
             map(
-                lambda x: np.all(np.array(test[x]) == np.array(expected)[x]),
+                lambda x: np.all(
+                    np.array(test[x]) == np.array(expected, dtype="object")[x]
+                ),
                 range(0, len(test)),
             )
         )
@@ -104,7 +106,9 @@ def test_take_list_arrays():
     assert np.all(
         list(
             map(
-                lambda x: np.all(np.array(test_large[x]) == np.array(expected)[x]),
+                lambda x: np.all(
+                    np.array(test_large[x]) == np.array(expected, dtype="object")[x]
+                ),
                 range(0, len(test_large)),
             )
         )


### PR DESCRIPTION
thanks for merging https://github.com/xhochy/fletcher/pull/180 !
I updated it with the fix of the overflow (exactly the same problem as in https://issues.apache.org/jira/browse/ARROW-10494).
I could add a test on this but it will take some time and memory to run.

```python
from fletcher._algorithms import take_on_pyarrow_list, pa, np
arr = pa.array([np.arange(x).astype(np.int8) for x in range(6)])
nb_repeat = 2**32 // arr.offsets.to_numpy()[-1]
indices = np.repeat(np.arange(len(arr)), nb_repeat)
take_on_pyarrow_list(arr, indices).validate()  # more than 1min30s
```